### PR TITLE
fix: method arguments not being parsed properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ $RECYCLE.BIN/
 native.d.ts
 native.js
 docs/
+test.js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,17 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,15 +19,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -48,6 +35,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
  "which",
 ]
 
@@ -84,30 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,23 +94,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -159,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -169,15 +120,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -186,15 +137,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -203,21 +154,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -255,12 +206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,24 +215,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "java"
-version = "2.1.4"
+version = "2.1.6"
 dependencies = [
  "bindgen",
  "futures",
@@ -362,9 +291,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "napi"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2f9ad803cde148d81d0ca9e5fd4d80773d15e992d09e3a44f62f41b9af4558"
+checksum = "bace9a4026eaa6631804e2ff9030c47beb0483fbb12dc17950fe1530c4961f84"
 dependencies = [
  "bitflags",
  "ctor",
@@ -382,9 +311,9 @@ checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
 
 [[package]]
 name = "napi-derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be75210f300e9fbf386ccac1c8eaaed23410e2f7f7aa9295b78c436a172ef51"
+checksum = "39f3d8b02ef355898ea98f69082d9a183c8701c836942c2daf3e92364e88a0fa"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -395,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ba4800264fac8a7726b208d5dd4c6d637d1027d73b026061a69d3339a0a930"
+checksum = "6c35640513eb442fcbd1653a1c112fb6b2cc12b54d82f9c141f5859c721cab36"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -443,12 +372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,9 +397,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -559,36 +482,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"
@@ -601,12 +503,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
+ "autocfg",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
 ]
 
@@ -648,15 +550,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,13 +30,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "clap",
+ "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -35,7 +48,6 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
  "which",
 ]
 
@@ -72,6 +84,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +128,19 @@ name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "futures"
@@ -206,12 +255,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -372,6 +443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +574,21 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thread_local"
@@ -550,6 +648,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 edition = "2021"
 name = "java"
-version = "2.1.4"
+version = "2.1.6"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "2.9.0", default-features = false, features = ["napi6", "tokio_rt"] }
-napi-derive = "2.9.0"
+napi = { version = "2.10.0", default-features = false, features = ["napi6", "tokio_rt"] }
+napi-derive = "2.9.1"
 libloading = "0.7.3"
-tokio = "1.2.0"
-futures = "0.3.21"
+tokio = "1.21.2"
+futures = "0.3.25"
 java-locator = "0.1.2"
 lazy_static = "1.4.0"
 rand = "0.8.5"
 
 [build-dependencies]
 napi-build = "2.0.1"
-bindgen = "0.60.1"
+bindgen = "0.61.0"
 java-locator = "0.1.2"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8.5"
 
 [build-dependencies]
 napi-build = "2.0.1"
-bindgen = "0.61.0"
+bindgen = "0.60.1"
 java-locator = "0.1.2"
 
 [profile.release]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "java-bridge",
-    "version": "2.1.5",
+    "version": "2.1.6-beta.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "java-bridge",
-            "version": "2.1.5",
+            "version": "2.1.6-beta.1",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "java-bridge",
-    "version": "2.1.6-beta.1",
+    "version": "2.1.6-beta.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "java-bridge",
-            "version": "2.1.6-beta.1",
+            "version": "2.1.6-beta.2",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "java-bridge",
-    "version": "2.1.6-beta.2",
+    "version": "2.1.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "java-bridge",
-            "version": "2.1.6-beta.2",
+            "version": "2.1.6",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-bridge",
-    "version": "2.1.6-beta.1",
+    "version": "2.1.6-beta.2",
     "main": "dist/index.prod.min.js",
     "types": "dist/ts-src/index.d.ts",
     "description": "A bridge between Node.js and Java APIs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-bridge",
-    "version": "2.1.6-beta.2",
+    "version": "2.1.6",
     "main": "dist/index.prod.min.js",
     "types": "dist/ts-src/index.d.ts",
     "description": "A bridge between Node.js and Java APIs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-bridge",
-    "version": "2.1.5",
+    "version": "2.1.6-beta.1",
     "main": "dist/index.prod.min.js",
     "types": "dist/ts-src/index.d.ts",
     "description": "A bridge between Node.js and Java APIs",

--- a/src/jni/java_env.rs
+++ b/src/jni/java_env.rs
@@ -187,6 +187,10 @@ impl<'a> JavaEnv<'a> {
         self.0.append_class_path(paths)
     }
 
+    pub fn replace_class_loader(&self, class_loader: GlobalJavaObject) -> ResultType<()> {
+        self.0.replace_class_loader(class_loader)
+    }
+
     pub(in crate::jni) fn thread_set_context_classloader(&self) -> ResultType<()> {
         if self.get_class_loader().is_err() {
             return Ok(());

--- a/src/jni/java_env_wrapper.rs
+++ b/src/jni/java_env_wrapper.rs
@@ -1286,12 +1286,16 @@ impl<'a> JavaEnvWrapper<'a> {
         )?;
 
         let res = GlobalJavaObject::try_from(class_loader)?;
+        self.replace_class_loader(res)
+    }
+
+    pub fn replace_class_loader(&self, loader: GlobalJavaObject) -> ResultType<()> {
         self.jvm
             .as_ref()
             .ok_or("The jvm was unset".to_string())?
             .lock()
             .unwrap()
-            .set_class_loader(res);
+            .set_class_loader(loader);
 
         Ok(())
     }

--- a/src/jni/java_type.rs
+++ b/src/jni/java_type.rs
@@ -1,3 +1,5 @@
+use crate::jni::java_env::JavaEnv;
+use crate::jni::objects::class::JavaClass;
 use crate::jni::util::util::{jni_type_to_java_type, ResultType};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Display, Formatter};
@@ -375,6 +377,10 @@ impl JavaType {
             || self.type_enum() == Type::Long
             || self.type_enum() == Type::Float
             || self.type_enum() == Type::Double
+    }
+
+    pub fn as_class<'a>(&self, env: &'a JavaEnv<'a>) -> ResultType<JavaClass<'a>> {
+        JavaClass::by_name(self.to_jni_type().as_str(), env)
     }
 }
 

--- a/src/jni/java_type.rs
+++ b/src/jni/java_type.rs
@@ -380,7 +380,20 @@ impl JavaType {
     }
 
     pub fn as_class<'a>(&self, env: &'a JavaEnv<'a>) -> ResultType<JavaClass<'a>> {
-        JavaClass::by_name(self.to_jni_type().as_str(), env)
+        let class_name = match self.type_enum {
+            Type::Void => "java.lang.Void",
+            Type::Long => "java.lang.Long",
+            Type::Integer => "java.lang.Integer",
+            Type::Boolean => "java.lang.Boolean",
+            Type::Byte => "java.lang.Byte",
+            Type::Character => "java.lang.Character",
+            Type::Short => "java.lang.Short",
+            Type::Float => "java.lang.Float",
+            Type::Double => "java.lang.Double",
+            _ => &self.signature,
+        };
+
+        JavaClass::by_java_name(class_name.to_string(), env)
     }
 }
 

--- a/src/jni/objects/java_object.rs
+++ b/src/jni/objects/java_object.rs
@@ -3,7 +3,7 @@ use crate::jni::objects::class::{GlobalJavaClass, JavaClass};
 use crate::jni::objects::object::{GlobalJavaObject, LocalJavaObject};
 use crate::jni::objects::string::JavaString;
 use crate::jni::objects::value::JavaValue;
-use crate::jni::traits::{GetRaw, GetSignature, ToJavaValue};
+use crate::jni::traits::{GetRaw, GetSignature, IsNull, ToJavaValue};
 use crate::jni::util::util::ResultType;
 use crate::sys;
 use std::error::Error;
@@ -28,6 +28,16 @@ impl<'a> JavaObject<'a> {
             Self::LocalRef(local_object) => JavaObject::LocalRef(local_object),
             Self::Local(local_object) => JavaObject::LocalRef(&local_object),
             Self::Global(global_object) => JavaObject::Global(global_object.clone()),
+        }
+    }
+}
+
+impl<'a> IsNull for JavaObject<'a> {
+    fn is_null(&self) -> bool {
+        match self {
+            Self::LocalRef(local_object) => local_object.is_null(),
+            Self::Local(local_object) => local_object.is_null(),
+            Self::Global(global_object) => global_object.is_null(),
         }
     }
 }

--- a/src/jni/objects/object.rs
+++ b/src/jni/objects/object.rs
@@ -208,7 +208,7 @@ impl GlobalJavaObjectInternal {
 
 impl Drop for GlobalJavaObjectInternal {
     fn drop(&mut self) {
-        if self.free {
+        if self.free && !self.is_null() {
             let vm = JavaVM::from_existing(self.jvm.clone(), self.options);
             let env = vm.attach_thread();
 
@@ -216,6 +216,12 @@ impl Drop for GlobalJavaObjectInternal {
                 env.delete_global_ref(self.object.load(Ordering::Relaxed));
             }
         }
+    }
+}
+
+impl IsNull for GlobalJavaObjectInternal {
+    fn is_null(&self) -> bool {
+        self.object.load(Ordering::Relaxed) == ptr::null_mut()
     }
 }
 

--- a/src/jni/objects/object.rs
+++ b/src/jni/objects/object.rs
@@ -256,6 +256,10 @@ impl GlobalJavaObject {
         env.get_object_class(self.into())
     }
 
+    pub fn get_vm(&self) -> JavaVM {
+        self.0.lock().unwrap().get_vm()
+    }
+
     /// Get this object's raw value in order to pass it
     /// to the JVM as a method return value.
     /// Disables automatic freeing of the object

--- a/src/node/java_call_result_ext.rs
+++ b/src/node/java_call_result_ext.rs
@@ -25,7 +25,7 @@ impl JavaCallResult {
             JavaCallResult::Character(c) => env.create_string_utf16(&[*c])?.into_unknown(),
             JavaCallResult::Short(s) => env.create_int32(*s as i32)?.into_unknown(),
             JavaCallResult::Integer(i) => env.create_int32(*i)?.into_unknown(),
-            JavaCallResult::Long(l) => env.create_int64(*l)?.into_unknown(),
+            JavaCallResult::Long(l) => env.create_bigint_from_i64(*l)?.into_unknown()?,
             JavaCallResult::Float(f) => env.create_double(*f as f64)?.into_unknown(),
             JavaCallResult::Double(d) => env.create_double(*d)?.into_unknown(),
             JavaCallResult::Object { object, signature } => {

--- a/src/node/java_class_instance.rs
+++ b/src/node/java_class_instance.rs
@@ -239,7 +239,7 @@ impl JavaClassInstance {
     }
 }
 
-#[js_function(1)]
+#[js_function(255)]
 fn constructor(ctx: CallContext) -> napi::Result<JsUnknown> {
     let new_target_func = ctx.get_new_target::<JsFunction>();
     if new_target_func.is_err() {
@@ -267,7 +267,7 @@ fn constructor(ctx: CallContext) -> napi::Result<JsUnknown> {
     Ok(ctx.env.get_undefined()?.into_unknown())
 }
 
-#[js_function(1)]
+#[js_function(255)]
 fn new_instance(ctx: CallContext) -> napi::Result<JsObject> {
     let proxy = JavaClassInstance::get_class_proxy(&ctx, true)?.clone();
     let constructor = proxy
@@ -404,7 +404,7 @@ fn set_static_field(env: Env, cls: JsObject, name: JsString, value: JsUnknown) -
     field.set_static(val).map_napi_err()
 }
 
-#[js_function(1)]
+#[js_function(0)]
 fn get_class_field(ctx: CallContext) -> napi::Result<JsObject> {
     let cls: JsFunction = ctx.this()?;
     let proxy_obj: JsObject = cls

--- a/src/node/java_type_ext.rs
+++ b/src/node/java_type_ext.rs
@@ -14,6 +14,8 @@ use crate::jni::traits::GetSignature;
 use crate::jni::util::util::ResultType;
 use crate::node::java_class_instance::OBJECT_PROPERTY;
 use crate::node::java_interface_proxy::JavaInterfaceProxy;
+use crate::node::js_to_java_object::{JsIntoJavaObject, JsToJavaClass};
+use crate::node::napi_error::MapToNapiError;
 use napi::{
     Env, JsBigInt, JsBoolean, JsFunction, JsNumber, JsObject, JsString, JsTypedArray, JsUnknown,
     ValueType,
@@ -40,36 +42,59 @@ fn is_integer(env: &Env, value: &JsNumber) -> ResultType<bool> {
         .get_value()?)
 }
 
-impl PartialEq<JsUnknown> for JavaType {
-    fn eq(&self, other: &JsUnknown) -> bool {
+pub trait JsTypeEq {
+    fn js_equals(&self, other: JsUnknown, env: &Env) -> napi::Result<bool>;
+}
+
+impl JsTypeEq for JavaType {
+    fn js_equals(&self, other: JsUnknown, env: &Env) -> napi::Result<bool> {
         match other.get_type().unwrap() {
-            ValueType::String => {
-                Type::String == self
-                    || (unsafe { other.cast::<JsString>() }.utf16_len().unwrap() == 1
-                        && self.is_char())
-            }
-            ValueType::Number => {
-                self.is_int()
-                    || self.is_double()
-                    || self.is_float()
-                    || self.is_long()
-                    || (value_may_be_byte(other) && self.is_byte())
-            }
-            ValueType::Boolean => self.is_boolean(),
-            ValueType::BigInt => self.is_long(),
+            ValueType::String => Ok(Type::String == self
+                || (unsafe { other.cast::<JsString>() }.utf16_len().unwrap() == 1
+                    && self.is_char())),
+            ValueType::Number => Ok(self.is_int()
+                || self.is_double()
+                || self.is_float()
+                || self.is_long()
+                || (value_may_be_byte(&other) && self.is_byte())),
+            ValueType::Boolean => Ok(self.is_boolean()),
+            ValueType::BigInt => Ok(self.is_long()),
             _ => {
                 if other.is_array().unwrap() && self.is_array() {
                     let arr = unsafe { other.cast::<JsTypedArray>() };
                     if arr.get_array_length().unwrap() == 0 {
-                        true
+                        Ok(true)
                     } else {
-                        self.inner().unwrap().lock().unwrap().deref()
-                            == &arr.get_element::<JsUnknown>(0).unwrap()
+                        self.inner()
+                            .unwrap()
+                            .lock()
+                            .unwrap()
+                            .deref()
+                            .js_equals(arr.get_element(0).unwrap(), env)
                     }
                 } else if other.is_buffer().unwrap() {
-                    self.is_byte_array()
+                    Ok(self.is_byte_array())
+                } else if Type::Object == self {
+                    Ok(true)
+                } else if !self.is_primitive() && !self.is_array() {
+                    let object = other.coerce_to_object();
+                    if object.is_err() {
+                        return Ok(false);
+                    }
+
+                    let object = object.unwrap();
+                    let class = object.to_java_class(env);
+                    if class.is_err() {
+                        return Ok(false);
+                    }
+
+                    let class = class.unwrap();
+                    let j_env = class.vm.attach_thread().map_napi_err()?;
+                    let self_class = self.as_class(&j_env).map_napi_err()?;
+                    let other_class = JavaClass::from_global(&class.class, &j_env);
+                    self_class.is_assignable_from(&other_class).map_napi_err()
                 } else {
-                    Type::Object == self
+                    Ok(false)
                 }
             }
         }
@@ -112,46 +137,82 @@ impl NapiToJava for JavaType {
     ) -> ResultType<JavaObject<'a>> {
         Ok(match self.type_enum() {
             Type::LangInteger | Type::Integer => {
-                let val = value.coerce_to_number()?.get_int32()?;
-                JavaObject::from(LocalJavaObject::from_i32(env, val)?)
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_int32()?;
+                    JavaObject::from(LocalJavaObject::from_i32(env, val)?)
+                }
             }
             Type::LangLong | Type::Long => {
-                let val = value.coerce_to_number()?.get_int64()?;
-                LocalJavaObject::from_i64(env, val)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_int64()?;
+                    LocalJavaObject::from_i64(env, val)?.into()
+                }
             }
             Type::LangFloat | Type::Float => {
-                let val = value.coerce_to_number()?.get_double()?;
-                LocalJavaObject::from_f32(env, val as f32)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_double()?;
+                    LocalJavaObject::from_f32(env, val as f32)?.into()
+                }
             }
             Type::LangDouble | Type::Double => {
-                let val = value.coerce_to_number()?.get_double()?;
-                LocalJavaObject::from_f64(env, val)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_double()?;
+                    LocalJavaObject::from_f64(env, val)?.into()
+                }
             }
             Type::LangBoolean | Type::Boolean => {
-                let val = value.coerce_to_bool()?.get_value()?;
-                LocalJavaObject::from_bool(env, val)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_bool()?.get_value()?;
+                    LocalJavaObject::from_bool(env, val)?.into()
+                }
             }
             Type::LangCharacter | Type::Character => {
-                let val = value.coerce_to_string()?.into_utf16()?;
-                let slice = val.as_slice();
-
-                if slice.len() == 1 {
-                    LocalJavaObject::from_char(env, slice[0])?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
                 } else {
-                    return Err("Java character must be a single character".into());
+                    let val = value.coerce_to_string()?.into_utf16()?;
+                    let slice = val.as_slice();
+
+                    if slice.len() == 1 {
+                        LocalJavaObject::from_char(env, slice[0])?.into()
+                    } else {
+                        return Err("Java character must be a single character".into());
+                    }
                 }
             }
             Type::LangByte | Type::Byte => {
-                let val = value.coerce_to_number()?.get_int32()?;
-                LocalJavaObject::from_byte(env, val as i8)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_int32()?;
+                    LocalJavaObject::from_byte(env, val as i8)?.into()
+                }
             }
             Type::LangShort | Type::Short => {
-                let val = value.coerce_to_number()?.get_int32()?;
-                LocalJavaObject::from_i16(env, val as i16)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_number()?.get_int32()?;
+                    LocalJavaObject::from_i16(env, val as i16)?.into()
+                }
             }
             Type::String => {
-                let val = value.coerce_to_string()?.into_utf16()?.as_str()?;
-                JavaString::try_from(val, env)?.into()
+                if value.get_type()? == ValueType::Object {
+                    JavaObject::from(value.into_java_object(node_env)?)
+                } else {
+                    let val = value.coerce_to_string()?.into_utf16()?.as_str()?;
+                    JavaString::try_from(val, env)?.into()
+                }
             }
             Type::Object | Type::LangObject => match value.get_type()? {
                 ValueType::Null | ValueType::Undefined => GlobalJavaObject::null(env)?.into(),
@@ -236,6 +297,15 @@ impl NapiToJava for JavaType {
         node_env: &'a Env,
         value: JsUnknown,
     ) -> ResultType<JavaCallResult> {
+        if value.get_type()? == ValueType::Object {
+            return Ok(JavaCallResult::Object {
+                object: self
+                    .convert_to_java_object(env, node_env, value)?
+                    .try_into()?,
+                signature: self.clone(),
+            });
+        }
+
         Ok(match self.type_enum() {
             Type::Integer => JavaCallResult::Integer(value.coerce_to_number()?.get_int32()?),
             Type::Long => JavaCallResult::Long(value.coerce_to_number()?.get_int64()?),

--- a/src/node/js_to_java_object.rs
+++ b/src/node/js_to_java_object.rs
@@ -1,0 +1,40 @@
+use crate::jni::objects::object::GlobalJavaObject;
+use crate::node::java_class_instance::{CLASS_PROXY_PROPERTY, OBJECT_PROPERTY};
+use crate::node::java_class_proxy::JavaClassProxy;
+use napi::{Env, JsObject, JsUnknown};
+use std::sync::Arc;
+
+pub trait JsIntoJavaObject {
+    fn into_java_object(self, env: &Env) -> napi::Result<GlobalJavaObject>;
+}
+
+pub trait JsToJavaObject {
+    fn to_java_object(&self, env: &Env) -> napi::Result<GlobalJavaObject>;
+}
+
+pub trait JsToJavaClass {
+    fn to_java_class(&self, env: &Env) -> napi::Result<Arc<JavaClassProxy>>;
+}
+
+impl JsToJavaObject for JsObject {
+    fn to_java_object(&self, env: &Env) -> napi::Result<GlobalJavaObject> {
+        let obj: JsObject = self.get_named_property(OBJECT_PROPERTY)?;
+        Ok(env.unwrap::<GlobalJavaObject>(&obj)?.clone())
+    }
+}
+
+impl JsIntoJavaObject for JsUnknown {
+    fn into_java_object(self, env: &Env) -> napi::Result<GlobalJavaObject> {
+        let obj: JsObject = self
+            .coerce_to_object()?
+            .get_named_property(OBJECT_PROPERTY)?;
+        Ok(env.unwrap::<GlobalJavaObject>(&obj)?.clone())
+    }
+}
+
+impl JsToJavaClass for JsObject {
+    fn to_java_class(&self, env: &Env) -> napi::Result<Arc<JavaClassProxy>> {
+        let obj: JsObject = self.get_named_property(CLASS_PROXY_PROPERTY)?;
+        Ok(env.unwrap::<Arc<JavaClassProxy>>(&obj)?.clone())
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -7,5 +7,6 @@ mod java_class_proxy;
 mod java_interface_proxy;
 pub mod java_options;
 mod java_type_ext;
+mod js_to_java_object;
 pub mod napi_error;
 mod stdout_redirect;

--- a/test/ClassTest.test.ts
+++ b/test/ClassTest.test.ts
@@ -33,7 +33,7 @@ function createClass(code: string, className: string): void {
 }
 
 describe('ClassTest', () => {
-    it('should create class', () => {
+    it('Create basic class', () => {
         createClass(
             `public class TestClass {
             public static String test = "abc";
@@ -68,23 +68,67 @@ describe('ClassTest', () => {
 
         expect(instance.s1).to.equal('s');
         expect(instance.l1).to.equal(1n);
-        expect(instance.l2).to.equal(2);
+        expect(instance.l2).to.equal(2n);
         expect(instance.l3).to.equal(3n);
         expect(instance.b1).to.equal(true);
 
         const instance2 = new Test('s', 1);
         expect(instance2.s1).to.equal('s');
         expect(instance2.l1).to.equal(1n);
-        expect(instance2.l2).to.equal(0);
+        expect(instance2.l2).to.equal(0n);
         expect(instance2.l3).to.equal(null);
         expect(instance2.b1).to.equal(false);
 
         const instance3 = new Test(1);
         expect(instance3.s1).to.equal(null);
         expect(instance3.l1).to.equal(1n);
-        expect(instance3.l2).to.equal(0);
+        expect(instance3.l2).to.equal(0n);
         expect(instance3.l3).to.equal(null);
         expect(instance3.b1).to.equal(false);
+    }).timeout(timeout);
+
+    it('Class with explicit java types', async () => {
+        createClass(
+            `
+        public class ClassWithExplicitJavaTypes {
+            public String s1;
+            public Long l1;
+            public long l2;
+            public Long l3;
+            public boolean b1;
+            
+            public ClassWithExplicitJavaTypes(String s1, Long l1, long l2, Long l3, boolean b1) {
+                this.s1 = s1;
+                this.l1 = l1;
+                this.l2 = l2;
+                this.l3 = l3;
+                this.b1 = b1;
+            }
+            
+            public ClassWithExplicitJavaTypes(String s1, Long l1) {
+                this(s1, l1, 0, null, false);
+            }
+            
+            public ClassWithExplicitJavaTypes(Long l1) {
+                this(null, l1, 0, null, false);
+            }
+        }
+        `,
+            'ClassWithExplicitJavaTypes'
+        );
+
+        const Test = importClass('ClassWithExplicitJavaTypes');
+        const JLong = importClass('java.lang.Long');
+
+        const l1 = new JLong(12000);
+        const instance = await Test.newInstanceAsync(l1);
+        console.log(instance);
+
+        expect(instance.s1).to.equal(null);
+        expect(instance.l1).to.equal(12000n);
+        expect(instance.l2).to.equal(0n);
+        expect(instance.l3).to.equal(null);
+        expect(instance.b1).to.equal(false);
     }).timeout(timeout);
 
     after(() => {

--- a/test/ClassTest.test.ts
+++ b/test/ClassTest.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import { importClass, setClassLoader, getClassLoader } from '../.';
+import path from 'path';
+import { expect } from 'chai';
+import * as os from 'os';
+
+let outDir: string | null = null;
+
+function createClass(code: string, className: string): void {
+    if (!outDir) {
+        outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'java'));
+    }
+
+    const classFile = path.join(outDir, className + '.java');
+    fs.writeFileSync(classFile, code, { encoding: 'utf8' });
+    const File = importClass('java.io.File');
+    const root = new File(outDir);
+
+    const ToolProvider = importClass('javax.tools.ToolProvider');
+    const compiler = ToolProvider.getSystemJavaCompilerSync();
+    compiler.runSync(null, null, null, [classFile]);
+
+    const URLClassLoader = importClass('java.net.URLClassLoader');
+    const prevClassLoader = getClassLoader();
+    const classLoader = URLClassLoader.newInstanceSync(
+        [root.toURISync().toURLSync()],
+        prevClassLoader
+    );
+
+    setClassLoader(classLoader);
+}
+
+describe('ClassTest', () => {
+    it('should create class', () => {
+        createClass(
+            `public class TestClass {
+            public static String test = "abc";
+            
+            public String s1;
+            public Long l1;
+            public long l2;
+            public Long l3;
+            public boolean b1;
+            
+            public TestClass(String s1, Long l1, long l2, Long l3, boolean b1) {
+                this.s1 = s1;
+                this.l1 = l1;
+                this.l2 = l2;
+                this.l3 = l3;
+                this.b1 = b1;
+            }
+        }`,
+            'TestClass'
+        );
+
+        const Test = importClass('TestClass');
+        const instance = new Test('s', 1, 2, 3, true);
+
+        expect(instance.s1).to.equal('s');
+        expect(instance.l1).to.equal(1n);
+        expect(instance.l2).to.equal(2);
+        expect(instance.l3).to.equal(3n);
+        expect(instance.b1).to.equal(true);
+    });
+
+    after(() => {
+        if (outDir) {
+            fs.rmSync(outDir, { recursive: true });
+        }
+    });
+});

--- a/test/ClassTest.test.ts
+++ b/test/ClassTest.test.ts
@@ -3,8 +3,10 @@ import { importClass, setClassLoader, getClassLoader } from '../.';
 import path from 'path';
 import { expect } from 'chai';
 import * as os from 'os';
+import { shouldIncreaseTimeout } from './testUtil';
 
 let outDir: string | null = null;
+const timeout = shouldIncreaseTimeout ? 60e3 : 20e3;
 
 function createClass(code: string, className: string): void {
     if (!outDir) {
@@ -49,6 +51,14 @@ describe('ClassTest', () => {
                 this.l3 = l3;
                 this.b1 = b1;
             }
+            
+            public TestClass(String s1, Long l1) {
+                this(s1, l1, 0, null, false);
+            }
+            
+            public TestClass(Long l1) {
+                this(null, l1, 0, null, false);
+            }
         }`,
             'TestClass'
         );
@@ -61,7 +71,21 @@ describe('ClassTest', () => {
         expect(instance.l2).to.equal(2);
         expect(instance.l3).to.equal(3n);
         expect(instance.b1).to.equal(true);
-    });
+
+        const instance2 = new Test('s', 1);
+        expect(instance2.s1).to.equal('s');
+        expect(instance2.l1).to.equal(1n);
+        expect(instance2.l2).to.equal(0);
+        expect(instance2.l3).to.equal(null);
+        expect(instance2.b1).to.equal(false);
+
+        const instance3 = new Test(1);
+        expect(instance3.s1).to.equal(null);
+        expect(instance3.l1).to.equal(1n);
+        expect(instance3.l2).to.equal(0);
+        expect(instance3.l3).to.equal(null);
+        expect(instance3.b1).to.equal(false);
+    }).timeout(timeout);
 
     after(() => {
         if (outDir) {

--- a/test/ClassTest.test.ts
+++ b/test/ClassTest.test.ts
@@ -38,7 +38,8 @@ function createClass(code: string, className: string): void {
 }
 
 describe('ClassTest', () => {
-    before(() => {
+    before(function () {
+        this.timeout(timeout);
         createClass(
             `public class BasicClass {
             public static String test = "abc";
@@ -148,7 +149,7 @@ describe('ClassTest', () => {
         expect(instance3.b1).to.equal(false);
     }).timeout(timeout);
 
-    it('Class with explicit java types', async () => {
+    it('Class with explicit java types', () => {
         const Test = importClass('ClassWithExplicitJavaTypes');
         const JLong = importClass('java.lang.Long');
         const JString = importClass('java.lang.String');
@@ -178,6 +179,46 @@ describe('ClassTest', () => {
         const instance3 = new Test(new JLong(5));
         expect(instance3.s1).to.equal(null);
         expect(instance3.l1).to.equal(5n);
+        expect(instance3.l2).to.equal(0n);
+        expect(instance3.l3).to.equal(null);
+        expect(instance3.b1).to.equal(false);
+    }).timeout(timeout);
+
+    it('Class with explicit java types (async)', async () => {
+        const Test = await importClassAsync('ClassWithExplicitJavaTypes');
+        const JLong = await importClassAsync('java.lang.Long');
+        const JString = await importClassAsync('java.lang.String');
+        const JBoolean = await importClassAsync('java.lang.Boolean');
+
+        const instance = await Test.newInstanceAsync(
+            await JString.newInstanceAsync('string'),
+            await JLong.newInstanceAsync(51),
+            await JLong.newInstanceAsync(61),
+            await JLong.newInstanceAsync(71),
+            await JBoolean.newInstanceAsync(true)
+        );
+
+        expect(instance.s1).to.equal('string');
+        expect(instance.l1).to.equal(51n);
+        expect(instance.l2).to.equal(61n);
+        expect(instance.l3).to.equal(71n);
+        expect(instance.b1).to.equal(true);
+
+        const instance2 = await Test.newInstanceAsync(
+            await JString.newInstanceAsync('string'),
+            await JLong.newInstanceAsync(52)
+        );
+        expect(instance2.s1).to.equal('string');
+        expect(instance2.l1).to.equal(52n);
+        expect(instance2.l2).to.equal(0n);
+        expect(instance2.l3).to.equal(null);
+        expect(instance2.b1).to.equal(false);
+
+        const instance3 = await Test.newInstanceAsync(
+            await JLong.newInstanceAsync(53)
+        );
+        expect(instance3.s1).to.equal(null);
+        expect(instance3.l1).to.equal(53n);
         expect(instance3.l2).to.equal(0n);
         expect(instance3.l3).to.equal(null);
         expect(instance3.b1).to.equal(false);

--- a/test/ObjectTest.test.ts
+++ b/test/ObjectTest.test.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { importClass } from '../.';
+
+describe('Object test', () => {
+    it('Create java.lang.Long from java.lang.String', () => {
+        const JLong = importClass('java.lang.Long');
+        const JString = importClass('java.lang.String');
+
+        const l1 = new JString('12000');
+        const l2 = new JLong(l1);
+        expect(l2.longValueSync()).to.equal(12000n);
+    });
+});

--- a/test/ProxyTest.test.ts
+++ b/test/ProxyTest.test.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { expect } from 'chai';
 import { afterEach } from 'mocha';
 import semver from 'semver';
-import isCi from 'is-ci';
+import { shouldIncreaseTimeout } from './testUtil';
 require('expose-gc');
 
 declare class JThread extends JavaClass {
@@ -29,10 +29,7 @@ function getJavaVersion(): string {
 }
 
 const javaVersion = getJavaVersion();
-let timeoutMs: number = 2e3;
-if (isCi && (process.arch === 'arm64' || process.arch === 'arm')) {
-    timeoutMs = 60e3;
-}
+const timeoutMs: number = shouldIncreaseTimeout ? 60e3 : 2e3;
 
 describe('ProxyTest', () => {
     describe('java.lang.Runnable proxy', () => {

--- a/test/TypescriptDefinitionGenerator.test.ts
+++ b/test/TypescriptDefinitionGenerator.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import ts from 'typescript';
 import path from 'path';
 import * as fs from 'fs';
-import isCi from 'is-ci';
+import { shouldIncreaseTimeout } from './testUtil';
 
 interface Diagnostics {
     message: string;
@@ -12,10 +12,7 @@ interface Diagnostics {
     code: number;
 }
 
-let timeoutMs: number = 30e3;
-if (isCi && (process.arch === 'arm64' || process.arch === 'arm')) {
-    timeoutMs = 600e3;
-}
+const timeoutMs: number = shouldIncreaseTimeout ? 600e3 : 30e3;
 
 function checkTypescriptSyntax(baseDirectory: string): Diagnostics[] {
     const program = ts.createProgram([path.join(baseDirectory, 'index.ts')], {

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -1,0 +1,4 @@
+import isCi from 'is-ci';
+
+export const shouldIncreaseTimeout =
+    isCi && (process.arch === 'arm64' || process.arch === 'arm');

--- a/test/utilTest.test.ts
+++ b/test/utilTest.test.ts
@@ -1,12 +1,9 @@
 import { getJavaVersion, getJavaVersionSync } from '../.';
 import { it } from 'mocha';
 import { expect } from 'chai';
-import isCI from 'is-ci';
+import { shouldIncreaseTimeout } from './testUtil';
 
-let timeout = 2e3;
-if (isCI && (process.arch === 'arm' || process.arch === 'arm64')) {
-    timeout = 20e3;
-}
+const timeout = shouldIncreaseTimeout ? 20e3 : 2e3;
 
 describe('util test', () => {
     it('Get java version', async () => {


### PR DESCRIPTION
## Changes made
* fixed constructor arguments getting truncated
* fixed fields containing null values throwing errors
* fixed an issue where passing class instances representing primitives caused the method/constructor to not be found
* fixed public properties not being added to class instances
* made long return types always return bigint

fixes #29 