### PR TITLE
fix(tsDefGen): create methods using the proper `newInstanceAsync` name

### DIFF
--- a/ts-src/TypescriptDefinitionGenerator.ts
+++ b/ts-src/TypescriptDefinitionGenerator.ts
@@ -340,7 +340,7 @@ export default class TypescriptDefinitionGenerator {
                     isStatic: true,
                     isDefault: false,
                 },
-                'newInstance',
+                'newInstanceAsync',
                 i,
                 false,
                 true


### PR DESCRIPTION
closes #66 