### PR TITLE
feat: allow use of async proxy methods

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -2,6 +2,9 @@ name: Address Sanitizer
 
 on:
     push:
+        branches:
+            - main
+    pull_request:
 
 jobs:
     build-and-test:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,5 +1,9 @@
 name: Check-style
-on: [push]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
 
 jobs:
     check-style:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
     push:
+        branches:
+            - main
+    pull_request:
 
 env:
     CARGO_TERM_COLOR: always

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -727,32 +727,23 @@ export function newProxy<T extends ProxyRecord<T> = AnyProxyRecord>(
             try {
                 const res = (method as ProxyMethod)(...args);
                 if (res instanceof Promise) {
-                    res.then((res: unknown) => callback(null, res))
-                        .catch((e: unknown) => {
+                    res.then((res: unknown) => callback(null, res)).catch(
+                        (e: unknown) => {
                             if (e instanceof Error) {
                                 callback(e);
                             } else {
                                 callback(new Error(String(e)));
                             }
-                        });
+                        }
+                    );
                 } else {
                     callback(null, res);
                 }
-            } catch (e: any) {
+            } catch (e: unknown) {
                 if (e instanceof Error) {
                     callback(e);
                 } else {
-                    callback(new Error(e.toString()));
-                }
-            }
-            try {
-                const res = (method as ProxyMethod)(...args);
-                callback(null, res);
-            } catch (e: any) {
-                if (e instanceof Error) {
-                    callback(e);
-                } else {
-                    callback(new Error(e.toString()));
+                    callback(new Error(String(e)));
                 }
             }
         };

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -724,6 +724,18 @@ export function newProxy<T extends ProxyRecord<T> = AnyProxyRecord>(
                 throw err;
             }
 
+            if (method.constructor.name === 'AsyncFunction') {
+              return (method as ProxyMethod)(...args)
+                  .then( (res: unknown) => callback(null, res))
+                  .catch( (e: unknown) => {
+                      if (e instanceof Error) {
+                          callback(e);
+                      } else {
+                          callback(new Error(String(e)));
+                      }
+                  });
+            }            
+            
             try {
                 const res = (method as ProxyMethod)(...args);
                 callback(null, res);

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -724,18 +724,27 @@ export function newProxy<T extends ProxyRecord<T> = AnyProxyRecord>(
                 throw err;
             }
 
-            if (method.constructor.name === 'AsyncFunction') {
-              return (method as ProxyMethod)(...args)
-                  .then( (res: unknown) => callback(null, res))
-                  .catch( (e: unknown) => {
-                      if (e instanceof Error) {
-                          callback(e);
-                      } else {
-                          callback(new Error(String(e)));
-                      }
-                  });
-            }            
-            
+            try {
+                const res = (method as ProxyMethod)(...args);
+                if (res instanceof Promise) {
+                    res.then((res: unknown) => callback(null, res))
+                        .catch((e: unknown) => {
+                            if (e instanceof Error) {
+                                callback(e);
+                            } else {
+                                callback(new Error(String(e)));
+                            }
+                        });
+                } else {
+                    callback(null, res);
+                }
+            } catch (e: any) {
+                if (e instanceof Error) {
+                    callback(e);
+                } else {
+                    callback(new Error(e.toString()));
+                }
+            }
             try {
                 const res = (method as ProxyMethod)(...args);
                 callback(null, res);


### PR DESCRIPTION
Hello Markus.
I've been testing your amazing project for a few days now. While using the proxy, I encountered the problem of having to implement the proxy with synchronous methods.

I tested locally in my async function support solution and it seems to work fine. Please see if this could be added to the project.
Regards.