### PR TITLE
feat(bridge): improve config

### DIFF
--- a/crates/java-bridge/src/node/config.rs
+++ b/crates/java-bridge/src/node/config.rs
@@ -1,5 +1,6 @@
 use std::sync::{Mutex, MutexGuard};
 
+use crate::node::java_class_instance::EMPTY_STRING;
 use lazy_static::lazy_static;
 use smart_default::SmartDefault;
 
@@ -7,14 +8,80 @@ lazy_static! {
     static ref CONFIG: Mutex<Config> = Mutex::new(Config::default());
 }
 
-#[derive(SmartDefault, Clone)]
+/// Configuration for the Java class proxy.
+///
+/// @since 2.4.0
+#[napi(object)]
+pub struct ClassConfiguration {
+    /// If true, the event loop will be run when an interface proxy is active.
+    pub run_event_loop_when_interface_proxy_is_active: Option<bool>,
+    /// If true, the custom inspect method will be used to display the object in the console.
+    pub custom_inspect: Option<bool>,
+    /// The suffix to use for synchronous methods.
+    pub sync_suffix: Option<String>,
+    /// The suffix to use for asynchronous methods.
+    pub async_suffix: Option<String>,
+}
+
+impl TryFrom<ClassConfiguration> for Config {
+    type Error = napi::Error;
+
+    fn try_from(value: ClassConfiguration) -> napi::Result<Self> {
+        let config = Config::get();
+        let async_suffix = config.async_suffix.as_ref();
+        let sync_suffix = config.sync_suffix.as_ref();
+
+        if value
+            .sync_suffix
+            .as_ref()
+            .or(sync_suffix)
+            .unwrap_or(&EMPTY_STRING)
+            == value
+                .async_suffix
+                .as_ref()
+                .or(async_suffix)
+                .unwrap_or(&EMPTY_STRING)
+        {
+            return Err(napi::Error::from_reason(
+                "syncSuffix and asyncSuffix cannot be the same",
+            ));
+        }
+
+        Ok(Self {
+            run_event_loop_when_interface_proxy_is_active: value
+                .run_event_loop_when_interface_proxy_is_active
+                .unwrap_or(config.run_event_loop_when_interface_proxy_is_active),
+            custom_inspect: value.custom_inspect.unwrap_or(config.custom_inspect),
+            sync_suffix: value.sync_suffix.or(sync_suffix.map(|s| s.clone())),
+            async_suffix: value.async_suffix.or(async_suffix.map(|s| s.clone())),
+        })
+    }
+}
+
+/// Configuration for the Java class proxy.
+///
+/// @since 2.4.0
+#[napi(object)]
+#[derive(SmartDefault, Clone, Eq, PartialEq)]
 pub struct Config {
+    /// If true, the event loop will be run when an interface proxy is active.
+    ///
+    /// @since 2.2.3
     #[default(false)]
     pub run_event_loop_when_interface_proxy_is_active: bool,
+    /// If true, the custom inspect method will be used to display the object in the console.
+    ///
+    /// @since 2.4.0
     #[default(false)]
     pub custom_inspect: bool,
+    /// The suffix to use for synchronous methods.
+    ///
+    /// @since 2.4.0
     #[default(Some("Sync".to_string()))]
     pub sync_suffix: Option<String>,
+    /// The suffix to use for asynchronous methods.
+    ///
+    /// @since 2.4.0
     #[default(None)]
     pub async_suffix: Option<String>,
 }

--- a/crates/java-bridge/src/node/config.rs
+++ b/crates/java-bridge/src/node/config.rs
@@ -7,12 +7,16 @@ lazy_static! {
     static ref CONFIG: Mutex<Config> = Mutex::new(Config::default());
 }
 
-#[derive(SmartDefault)]
+#[derive(SmartDefault, Clone)]
 pub struct Config {
     #[default(false)]
     pub run_event_loop_when_interface_proxy_is_active: bool,
     #[default(false)]
     pub custom_inspect: bool,
+    #[default(Some("Sync".to_string()))]
+    pub sync_suffix: Option<String>,
+    #[default(None)]
+    pub async_suffix: Option<String>,
 }
 
 impl Config {

--- a/crates/java-bridge/src/node/extensions/java_call_result_ext.rs
+++ b/crates/java-bridge/src/node/extensions/java_call_result_ext.rs
@@ -170,7 +170,7 @@ impl ToNapiValue for JavaCallResult {
                     )?
                 } else {
                     let vm = j_env.get_java_vm()?;
-                    let proxy = get_class_proxy(&vm, signature.to_string())?;
+                    let proxy = get_class_proxy(&vm, signature.to_string(), None)?;
 
                     JavaClassInstance::from_existing(proxy, env, object.clone())?
                 }

--- a/crates/java-bridge/src/node/extensions/java_type_ext.rs
+++ b/crates/java-bridge/src/node/extensions/java_type_ext.rs
@@ -49,6 +49,7 @@ impl JsTypeEq for JavaType {
         Ok(match other.get_type()? {
             ValueType::String => {
                 Type::String == self
+                    || Type::CharSequence == self
                     || (other.coerce_to_string()?.utf16_len()? == 1 && self.is_char())
             }
             ValueType::Number => {
@@ -235,7 +236,7 @@ impl NapiToJava for JavaType {
                     LocalJavaObject::from_i16(env, val as i16)?.into()
                 }
             }
-            Type::String => {
+            Type::String | Type::CharSequence => {
                 if value.get_type()? == ValueType::Object {
                     JavaObject::from(value.into_java_object(node_env)?)
                 } else {

--- a/crates/java-bridge/src/node/java.rs
+++ b/crates/java-bridge/src/node/java.rs
@@ -243,6 +243,14 @@ impl Java {
         j_env.replace_class_loader(instance.clone()).map_napi_err()
     }
 
+    /// Clear the class proxy cache.
+    /// Use this method in order to reset the config for all class proxies.
+    /// The new config will be applied once the class is imported again.
+    #[napi]
+    pub fn clear_class_proxies() {
+        CACHED_CLASSES.lock().unwrap().clear();
+    }
+
     pub fn vm(&self) -> JavaVM {
         self.root_vm.clone()
     }

--- a/crates/java-bridge/src/node/java.rs
+++ b/crates/java-bridge/src/node/java.rs
@@ -1,3 +1,4 @@
+use crate::node::config::{ClassConfiguration, Config};
 use crate::node::helpers::napi_error::{MapToNapiError, StrIntoNapiError};
 use crate::node::interface_proxy::interface_proxy_options::InterfaceProxyOptions;
 use crate::node::interface_proxy::java_interface_proxy::JavaInterfaceProxy;
@@ -26,12 +27,40 @@ lazy_static! {
         Mutex::new(HashMap::new());
 }
 
-pub fn get_class_proxy(vm: &JavaVM, class_name: String) -> ResultType<Arc<JavaClassProxy>> {
+pub fn get_class_proxy(
+    vm: &JavaVM,
+    class_name: String,
+    config: Option<ClassConfiguration>,
+) -> ResultType<Arc<JavaClassProxy>> {
+    let config = config
+        .map(|c| c.try_into())
+        .map_or(Ok(None), |c| c.map(Some))?;
     let mut cached_classes = CACHED_CLASSES.lock().unwrap();
-    if cached_classes.contains_key(class_name.as_str()) {
-        Ok(cached_classes.get(class_name.as_str()).unwrap().clone())
+
+    if let Some(proxy) = cached_classes.get(&class_name) {
+        if let Some(cfg) = config {
+            if proxy.config != cfg {
+                return Ok(Arc::new(JavaClassProxy::new(
+                    vm.clone(),
+                    class_name.clone(),
+                    Some(cfg),
+                )?));
+            }
+        }
+
+        Ok(proxy.clone())
     } else {
-        let proxy = Arc::new(JavaClassProxy::new(vm.clone(), class_name.clone())?);
+        if let Some(cfg) = config.as_ref() {
+            if !Config::get().eq(&cfg) {
+                return Ok(Arc::new(JavaClassProxy::new(
+                    vm.clone(),
+                    class_name.clone(),
+                    Some(cfg.clone()),
+                )?));
+            }
+        }
+
+        let proxy = Arc::new(JavaClassProxy::new(vm.clone(), class_name.clone(), config)?);
         cached_classes.insert(class_name, proxy.clone());
 
         Ok(proxy)
@@ -108,8 +137,13 @@ impl Java {
     /// Will import the class and parse all of its methods and fields.
     /// The imported class will be cached for future use.
     #[napi(ts_return_type = "object")]
-    pub fn import_class(&mut self, env: Env, class_name: String) -> napi::Result<JsFunction> {
-        let proxy = get_class_proxy(&self.root_vm, class_name).map_napi_err()?;
+    pub fn import_class(
+        &mut self,
+        env: Env,
+        class_name: String,
+        config: Option<ClassConfiguration>,
+    ) -> napi::Result<JsFunction> {
+        let proxy = get_class_proxy(&self.root_vm, class_name, config).map_napi_err()?;
         JavaClassInstance::create_class_instance(&env, proxy)
     }
 
@@ -121,9 +155,10 @@ impl Java {
         &'static mut self,
         env: Env,
         class_name: String,
+        config: Option<ClassConfiguration>,
     ) -> napi::Result<JsObject> {
         env.execute_tokio_future(
-            future::lazy(|_| get_class_proxy(&self.root_vm, class_name).map_napi_err()),
+            future::lazy(|_| get_class_proxy(&self.root_vm, class_name, config).map_napi_err()),
             |&mut env, proxy| JavaClassInstance::create_class_instance(&env, proxy),
         )
     }
@@ -223,8 +258,8 @@ impl Java {
 
     #[napi(getter, ts_return_type = "object")]
     pub fn get_class_loader(&self, env: Env) -> napi::Result<JsUnknown> {
-        let proxy =
-            get_class_proxy(&self.root_vm, "java.net.URLClassLoader".into()).map_napi_err()?;
+        let proxy = get_class_proxy(&self.root_vm, "java.net.URLClassLoader".into(), None)
+            .map_napi_err()?;
         let j_env = self.root_vm.attach_thread().map_napi_err()?;
         JavaClassInstance::from_existing(proxy, &env, j_env.get_class_loader().map_napi_err()?)
     }
@@ -241,14 +276,6 @@ impl Java {
             env.unwrap::<GlobalJavaObject>(&obj.get_named_property::<JsObject>(OBJECT_PROPERTY)?)?;
 
         j_env.replace_class_loader(instance.clone()).map_napi_err()
-    }
-
-    /// Clear the class proxy cache.
-    /// Use this method in order to reset the config for all class proxies.
-    /// The new config will be applied once the class is imported again.
-    #[napi]
-    pub fn clear_class_proxies() {
-        CACHED_CLASSES.lock().unwrap().clear();
     }
 
     pub fn vm(&self) -> JavaVM {
@@ -289,4 +316,14 @@ impl Java {
         env.instance_of(JavaObject::from(this.clone()), other)
             .map_napi_err()
     }
+}
+
+/// Clear the class proxy cache.
+/// Use this method in order to reset the config for all class proxies.
+/// The new config will be applied once the class is imported again.
+///
+/// @since 2.4.0
+#[napi]
+pub fn clear_class_proxies() {
+    CACHED_CLASSES.lock().unwrap().clear();
 }

--- a/crates/java-bridge/src/node/java_class_instance.rs
+++ b/crates/java-bridge/src/node/java_class_instance.rs
@@ -6,12 +6,12 @@ use crate::node::helpers::napi_ext::{load_napi_library, uv_run, uv_run_mode};
 use crate::node::interface_proxy::proxies::interface_proxy_exists;
 use crate::node::java::Java;
 use crate::node::java_class_proxy::JavaClassProxy;
+use crate::node::util::traits::UnwrapOrEmpty;
 use futures::future;
 use java_rs::java_call_result::JavaCallResult;
 use java_rs::java_type::JavaType;
 use java_rs::objects::class::GlobalJavaClass;
 use java_rs::objects::object::GlobalJavaObject;
-use lazy_static::lazy_static;
 use napi::{
     CallContext, Env, JsBoolean, JsFunction, JsObject, JsUnknown, Property, PropertyAttributes,
     Status,
@@ -22,10 +22,6 @@ use std::time::Duration;
 
 pub const CLASS_PROXY_PROPERTY: &str = "class.proxy";
 pub const OBJECT_PROPERTY: &str = "class.object";
-
-lazy_static! {
-    pub static ref EMPTY_STRING: String = "".to_string();
-}
 
 pub struct JavaClassInstance;
 
@@ -54,10 +50,8 @@ impl JavaClassInstance {
         for method in &proxy.static_methods {
             let name = method.0.clone();
             let name_cpy = name.clone();
-            let name_async =
-                name.clone() + proxy.config.async_suffix.as_ref().unwrap_or(&EMPTY_STRING);
-            let name_sync =
-                name.clone() + proxy.config.sync_suffix.as_ref().unwrap_or(&EMPTY_STRING);
+            let name_async = name.clone() + proxy.config.async_suffix.unwrap_or_empty();
+            let name_sync = name.clone() + proxy.config.sync_suffix.unwrap_or_empty();
 
             constructor.set_named_property(
                 name_sync.clone().as_str(),
@@ -188,10 +182,8 @@ impl JavaClassInstance {
 
             let name = method.0.clone();
             let name_cpy = name.clone();
-            let name_async =
-                name.clone() + proxy.config.async_suffix.as_ref().unwrap_or(&EMPTY_STRING);
-            let name_sync =
-                name.clone() + proxy.config.sync_suffix.as_ref().unwrap_or(&EMPTY_STRING);
+            let name_async = name.clone() + proxy.config.async_suffix.unwrap_or_empty();
+            let name_sync = name.clone() + proxy.config.sync_suffix.unwrap_or_empty();
 
             this.set_named_property(
                 name_sync.clone().as_str(),

--- a/crates/java-bridge/src/node/java_class_proxy.rs
+++ b/crates/java-bridge/src/node/java_class_proxy.rs
@@ -22,7 +22,7 @@ pub struct JavaClassProxy {
 }
 
 impl JavaClassProxy {
-    pub fn new(vm: JavaVM, class_name: String) -> ResultType<Self> {
+    pub fn new(vm: JavaVM, class_name: String, config: Option<Config>) -> ResultType<Self> {
         let env = vm.attach_thread()?;
         let class = env.find_global_class_by_java_name(class_name.clone())?;
 
@@ -35,7 +35,7 @@ impl JavaClassProxy {
             static_fields: ClassField::get_class_fields(vm.clone(), class_name.clone(), true)?,
             constructors: ClassConstructor::get_constructors(vm, class_name.clone())?,
             class_name,
-            config: Config::get().clone(),
+            config: config.unwrap_or_else(|| Config::get().clone()),
         })
     }
 

--- a/crates/java-bridge/src/node/java_class_proxy.rs
+++ b/crates/java-bridge/src/node/java_class_proxy.rs
@@ -1,6 +1,7 @@
 use crate::java::class_constructor::ClassConstructor;
 use crate::java::class_field::ClassField;
 use crate::java::class_method::ClassMethod;
+use crate::node::config::Config;
 use crate::node::extensions::class_ext::ArgumentMatch;
 use java_rs::java_vm::JavaVM;
 use java_rs::objects::class::GlobalJavaClass;
@@ -17,6 +18,7 @@ pub struct JavaClassProxy {
     pub static_fields: HashMap<String, ClassField>,
     pub constructors: Vec<ClassConstructor>,
     pub class_name: String,
+    pub config: Config,
 }
 
 impl JavaClassProxy {
@@ -33,6 +35,7 @@ impl JavaClassProxy {
             static_fields: ClassField::get_class_fields(vm.clone(), class_name.clone(), true)?,
             constructors: ClassConstructor::get_constructors(vm, class_name.clone())?,
             class_name,
+            config: Config::get().clone(),
         })
     }
 

--- a/crates/java-bridge/src/node/java_config.rs
+++ b/crates/java-bridge/src/node/java_config.rs
@@ -1,36 +1,120 @@
 use crate::node::config::Config;
-use crate::node::java_class_instance::EMPTY_STRING;
+use crate::node::util::traits::UnwrapOrEmpty;
 
+/// Configuration options for the java bridge.
+///
+/// As of version 2.4.0, the options are cached inside the class proxy cache.
+/// This means that changing the options will not affect any class proxies
+/// that have already been created by importing a class using {@link importClass}
+/// or {@link importClassAsync}. You must clear the class proxy cache using the
+/// {@link clearClassProxies} method in order to apply the new options to all
+/// classes imported at a later date. This does not affect already instantiated
+/// or imported classes.
+///
+/// Do not instantiate this class. Use the {@link default.config} instance instead.
+///
+/// @since 2.2.3
 #[napi]
 pub struct JavaConfig;
 
 #[napi]
 impl JavaConfig {
-    #[napi]
-    pub fn set_run_event_loop_when_interface_proxy_is_active(value: bool) {
+    /// Do not instantiate this class.
+    /// Use the {@link default.config} instance instead.
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// **Experimental Feature**
+    ///
+    /// Set whether to run the event loop when an interface proxy is active.
+    /// This is disabled by default. Enabling this will cause the bridge
+    /// to run the event loop when an interface proxy either as direct
+    /// proxy or as daemon proxy is active. This is only required if the
+    /// proxied method calls back into the javascript process in the same thread.
+    /// If the proxy is used either in an async method or in a different thread,
+    /// this is not required.
+    ///
+    /// **Note:** Enabling this may cause the application to crash. Use with caution.
+    ///
+    /// @since 2.2.3
+    /// @experimental
+    /// @param value whether to run the event loop when an interface proxy is active
+    #[napi(setter)]
+    pub fn set_run_event_loop_when_interface_proxy_is_active(&self, value: bool) {
         Config::get().run_event_loop_when_interface_proxy_is_active = value;
     }
 
-    #[napi]
-    pub fn get_run_event_loop_when_interface_proxy_is_active() -> bool {
+    /// **Experimental Feature**
+    ///
+    /// Get whether to run the event loop when an interface proxy is active.
+    /// @since 2.2.3
+    /// @experimental
+    #[napi(getter)]
+    pub fn get_run_event_loop_when_interface_proxy_is_active(&self) -> bool {
         Config::get().run_event_loop_when_interface_proxy_is_active
     }
 
-    #[napi]
-    pub fn set_custom_inspect(value: bool) {
+    /// Whether to add custom inspect methods to java objects.
+    /// This is disabled by default.
+    /// This allows console.log to print java objects in a more readable way
+    /// using the `toString` method of the java object.
+    ///
+    /// @since 2.4.0
+    /// @param value whether to add custom inspect methods to java objects
+    #[napi(setter)]
+    pub fn set_custom_inspect(&self, value: bool) {
         Config::get().custom_inspect = value;
     }
 
-    #[napi]
-    pub fn get_custom_inspect() -> bool {
+    /// Get whether to add custom inspect methods to java objects.
+    ///
+    /// @since 2.4.0
+    /// @returns whether to add custom inspect methods to java objects
+    #[napi(getter)]
+    pub fn get_custom_inspect(&self) -> bool {
         Config::get().custom_inspect
     }
 
-    #[napi]
-    pub fn set_sync_suffix(value: Option<String>) -> napi::Result<()> {
-        if value.as_ref().unwrap_or(&EMPTY_STRING)
-            == Config::get().async_suffix.as_ref().unwrap_or(&EMPTY_STRING)
-        {
+    /// Set the suffix for synchronous methods.
+    /// This is `Sync` by default.
+    /// Pass `null` or an empty string to disable the suffix.
+    /// This must not be the same as the {@link asyncSuffix}.
+    ///
+    /// # Example
+    /// ```ts
+    /// import { config, clearClassProxies } from 'java-bridge';
+    ///
+    /// // Set the async suffix in order to prevent errors
+    /// config.asyncSuffix = 'Async';
+    /// // Set the sync suffix to an empty string
+    /// config.syncSuffix = '';
+    /// // This would do the same
+    /// config.syncSuffix = null;
+    ///
+    /// // Clear the class proxy cache
+    /// clearClassProxies();
+    ///
+    /// // Import the class
+    /// const ArrayList = importClass('java.util.ArrayList');
+    ///
+    /// // Create a new instance
+    /// const list = new ArrayList();
+    ///
+    /// // Call the method
+    /// list.add('Hello World!');
+    ///
+    /// // Async methods now have the 'Async' suffix
+    /// await list.addAsync('Hello World!');
+    /// ```
+    ///
+    /// @see asyncSuffix
+    /// @since 2.4.0
+    /// @param value the suffix to use for synchronous methods
+    #[napi(setter, ts_args_type = "value: string | undefined | null")]
+    pub fn set_sync_suffix(&self, value: Option<String>) -> napi::Result<()> {
+        if value.unwrap_or_empty() == Config::get().async_suffix.unwrap_or_empty() {
             Err(napi::Error::from_reason(
                 "syncSuffix and asyncSuffix cannot be the same",
             ))
@@ -40,16 +124,25 @@ impl JavaConfig {
         }
     }
 
-    #[napi]
-    pub fn get_sync_suffix() -> Option<String> {
+    /// Get the suffix for synchronous methods.
+    ///
+    /// @since 2.4.0
+    #[napi(getter)]
+    pub fn get_sync_suffix(&self) -> Option<String> {
         Config::get().sync_suffix.clone()
     }
 
-    #[napi]
-    pub fn set_async_suffix(value: Option<String>) -> napi::Result<()> {
-        if value.as_ref().unwrap_or(&EMPTY_STRING)
-            == Config::get().sync_suffix.as_ref().unwrap_or(&EMPTY_STRING)
-        {
+    /// Set the suffix for asynchronous methods.
+    /// This is `Async` by default.
+    /// Pass `null` or an empty string to disable the suffix.
+    /// This must not be the same as the {@link syncSuffix}.
+    ///
+    /// @see syncSuffix
+    /// @since 2.4.0
+    /// @param value the suffix to use for asynchronous methods
+    #[napi(setter, ts_args_type = "value: string | undefined | null")]
+    pub fn set_async_suffix(&self, value: Option<String>) -> napi::Result<()> {
+        if value.unwrap_or_empty() == Config::get().sync_suffix.unwrap_or_empty() {
             Err(napi::Error::from_reason(
                 "syncSuffix and asyncSuffix cannot be the same",
             ))
@@ -59,16 +152,22 @@ impl JavaConfig {
         }
     }
 
-    #[napi]
-    pub fn get_async_suffix() -> Option<String> {
+    /// Get the suffix for asynchronous methods.
+    ///
+    /// @since 2.4.0
+    #[napi(getter)]
+    pub fn get_async_suffix(&self) -> Option<String> {
         Config::get().async_suffix.clone()
     }
 
-    #[napi]
-    pub fn set(value: Config) -> napi::Result<()> {
-        if value.async_suffix.as_ref().unwrap_or(&EMPTY_STRING)
-            == value.sync_suffix.as_ref().unwrap_or(&EMPTY_STRING)
-        {
+    /// Override the whole config.
+    /// If you want to change only a single field, use the static setters instead.
+    ///
+    /// @since 2.4.0
+    /// @param value the config to use
+    #[napi(setter)]
+    pub fn set_config(&self, value: Config) -> napi::Result<()> {
+        if value.async_suffix.unwrap_or_empty() == value.sync_suffix.unwrap_or_empty() {
             Err(napi::Error::from_reason(
                 "syncSuffix and asyncSuffix cannot be the same",
             ))
@@ -78,13 +177,19 @@ impl JavaConfig {
         }
     }
 
-    #[napi]
-    pub fn get() -> Config {
+    /// Get the current config.
+    ///
+    /// @since 2.4.0
+    #[napi(getter)]
+    pub fn get_config(&self) -> Config {
         Config::get().clone()
     }
 
+    /// Reset the config to the default values.
+    ///
+    /// @since 2.4.0
     #[napi]
-    pub fn reset() {
+    pub fn reset(&self) {
         Config::get().clone_from(&Config::default());
     }
 }

--- a/crates/java-bridge/src/node/java_config.rs
+++ b/crates/java-bridge/src/node/java_config.rs
@@ -65,6 +65,25 @@ impl JavaConfig {
     }
 
     #[napi]
+    pub fn set(value: Config) -> napi::Result<()> {
+        if value.async_suffix.as_ref().unwrap_or(&EMPTY_STRING)
+            == value.sync_suffix.as_ref().unwrap_or(&EMPTY_STRING)
+        {
+            Err(napi::Error::from_reason(
+                "syncSuffix and asyncSuffix cannot be the same",
+            ))
+        } else {
+            Config::get().clone_from(&value);
+            Ok(())
+        }
+    }
+
+    #[napi]
+    pub fn get() -> Config {
+        Config::get().clone()
+    }
+
+    #[napi]
     pub fn reset() {
         Config::get().clone_from(&Config::default());
     }

--- a/crates/java-bridge/src/node/java_config.rs
+++ b/crates/java-bridge/src/node/java_config.rs
@@ -1,4 +1,5 @@
 use crate::node::config::Config;
+use crate::node::java_class_instance::EMPTY_STRING;
 
 #[napi]
 pub struct JavaConfig;
@@ -23,5 +24,48 @@ impl JavaConfig {
     #[napi]
     pub fn get_custom_inspect() -> bool {
         Config::get().custom_inspect
+    }
+
+    #[napi]
+    pub fn set_sync_suffix(value: Option<String>) -> napi::Result<()> {
+        if value.as_ref().unwrap_or(&EMPTY_STRING)
+            == Config::get().async_suffix.as_ref().unwrap_or(&EMPTY_STRING)
+        {
+            Err(napi::Error::from_reason(
+                "syncSuffix and asyncSuffix cannot be the same",
+            ))
+        } else {
+            Config::get().sync_suffix = value;
+            Ok(())
+        }
+    }
+
+    #[napi]
+    pub fn get_sync_suffix() -> Option<String> {
+        Config::get().sync_suffix.clone()
+    }
+
+    #[napi]
+    pub fn set_async_suffix(value: Option<String>) -> napi::Result<()> {
+        if value.as_ref().unwrap_or(&EMPTY_STRING)
+            == Config::get().sync_suffix.as_ref().unwrap_or(&EMPTY_STRING)
+        {
+            Err(napi::Error::from_reason(
+                "syncSuffix and asyncSuffix cannot be the same",
+            ))
+        } else {
+            Config::get().async_suffix = value;
+            Ok(())
+        }
+    }
+
+    #[napi]
+    pub fn get_async_suffix() -> Option<String> {
+        Config::get().async_suffix.clone()
+    }
+
+    #[napi]
+    pub fn reset() {
+        Config::get().clone_from(&Config::default());
     }
 }

--- a/crates/java-bridge/src/node/util/mod.rs
+++ b/crates/java-bridge/src/node/util/mod.rs
@@ -1,1 +1,2 @@
+pub mod traits;
 pub mod util;

--- a/crates/java-bridge/src/node/util/traits.rs
+++ b/crates/java-bridge/src/node/util/traits.rs
@@ -1,0 +1,21 @@
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref EMPTY_STRING: String = "".to_string();
+}
+
+pub trait UnwrapOrEmpty {
+    fn unwrap_or_empty(&self) -> &String;
+}
+
+impl UnwrapOrEmpty for Option<&String> {
+    fn unwrap_or_empty(&self) -> &String {
+        self.unwrap_or(&EMPTY_STRING)
+    }
+}
+
+impl UnwrapOrEmpty for Option<String> {
+    fn unwrap_or_empty(&self) -> &String {
+        self.as_ref().unwrap_or(&EMPTY_STRING)
+    }
+}

--- a/crates/java-rs/src/java/java_type.rs
+++ b/crates/java-rs/src/java/java_type.rs
@@ -31,6 +31,7 @@ pub enum Type {
     LangDouble = 18,
     LangObject = 19,
     String = 20,
+    CharSequence = 21,
 }
 
 impl Type {
@@ -47,7 +48,8 @@ impl Type {
             | Type::LangFloat
             | Type::LangDouble
             | Type::LangObject
-            | Type::String => true,
+            | Type::String
+            | Type::CharSequence => true,
             _ => false,
         }
     }
@@ -157,6 +159,9 @@ impl JavaType {
             }
             "java.lang.Object" => {
                 type_enum = Type::LangObject;
+            }
+            "java.lang.CharSequence" => {
+                type_enum = Type::CharSequence;
             }
             _ => {
                 if signature.ends_with("[]") {

--- a/crates/java-rs/src/java/objects/method.rs
+++ b/crates/java-rs/src/java/objects/method.rs
@@ -121,6 +121,7 @@ define_java_methods!(
         Type::Object,
         Type::LangBoolean,
         Type::String,
+        Type::CharSequence,
         Type::LangCharacter,
         Type::LangByte,
         Type::LangFloat,

--- a/test/ConfigTest.test.ts
+++ b/test/ConfigTest.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach } from 'mocha';
+import { clearClassProxies, config, importClass } from '../.';
+import { expect } from 'chai';
+
+describe('Config test', () => {
+    beforeEach(() => {
+        config.reset();
+        clearClassProxies();
+    });
+
+    afterEach(() => {
+        config.reset();
+        clearClassProxies();
+    });
+
+    it('reset', () => {
+        config.customInspect = true;
+        config.runEventLoopWhenInterfaceProxyIsActive = true;
+
+        expect(config.customInspect).to.be.true;
+        expect(config.runEventLoopWhenInterfaceProxyIsActive).to.be.true;
+
+        config.reset();
+
+        expect(config.customInspect).to.be.false;
+        expect(config.runEventLoopWhenInterfaceProxyIsActive).to.be.false;
+    });
+
+    it('custom inspect', () => {
+        config.customInspect = true;
+
+        expect(config.customInspect).to.be.true;
+
+        const JString = importClass('java.lang.String');
+        const str = new JString('test');
+
+        // @ts-ignore
+        expect(str[Symbol.for('nodejs.util.inspect.custom')]()).to.equal(
+            'test'
+        );
+    });
+
+    it('set async suffix', async () => {
+        config.asyncSuffix = 'Async';
+
+        expect(config.asyncSuffix).to.equal('Async');
+
+        const JString = importClass('java.lang.String');
+        const str = new JString('test');
+
+        expect(str.containsAsync).to.be.a('function');
+        const res = str.containsAsync('e');
+        expect(res).to.be.a('promise');
+        expect(await res).to.equal(true);
+    });
+
+    it('set sync suffix', () => {
+        config.syncSuffix = 'SyncSuffix';
+
+        expect(config.syncSuffix).to.equal('SyncSuffix');
+
+        const JString = importClass('java.lang.String');
+        const str = new JString('test');
+
+        expect(str.containsSyncSuffix).to.be.a('function');
+        expect(str.containsSyncSuffix('e')).to.equal(true);
+    });
+
+    it('set invalid suffix', () => {
+        const error = 'syncSuffix and asyncSuffix cannot be the same';
+        expect(() => (config.asyncSuffix = 'Sync')).to.throw(error);
+
+        config.asyncSuffix = null;
+        expect(() => (config.syncSuffix = null)).to.throw(error);
+        expect(() => (config.syncSuffix = '')).to.throw(error);
+
+        config.asyncSuffix = 'Async';
+        config.syncSuffix = '';
+
+        expect(() => (config.asyncSuffix = '')).to.throw(error);
+        expect(() => (config.asyncSuffix = null)).to.throw(error);
+    });
+});

--- a/test/ConfigTest.test.ts
+++ b/test/ConfigTest.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach } from 'mocha';
-import { clearClassProxies, config, importClass } from '../.';
+import { clearClassProxies, config, importClass, importClassAsync } from '../.';
 import { expect } from 'chai';
+import { JString } from './classes';
+
+const SUFFIX_ERROR = 'syncSuffix and asyncSuffix cannot be the same';
 
 describe('Config test', () => {
     beforeEach(() => {
@@ -31,8 +34,8 @@ describe('Config test', () => {
 
         expect(config.customInspect).to.be.true;
 
-        const JString = importClass('java.lang.String');
-        const str = new JString('test');
+        const JavaString = importClass<typeof JString>('java.lang.String');
+        const str = new JavaString('test');
 
         // @ts-ignore
         expect(str[Symbol.for('nodejs.util.inspect.custom')]()).to.equal(
@@ -45,8 +48,8 @@ describe('Config test', () => {
 
         expect(config.asyncSuffix).to.equal('Async');
 
-        const JString = importClass('java.lang.String');
-        const str = new JString('test');
+        const JavaString = importClass('java.lang.String');
+        const str = new JavaString('test');
 
         expect(str.containsAsync).to.be.a('function');
         const res = str.containsAsync('e');
@@ -59,25 +62,135 @@ describe('Config test', () => {
 
         expect(config.syncSuffix).to.equal('SyncSuffix');
 
-        const JString = importClass('java.lang.String');
-        const str = new JString('test');
+        const JavaString = importClass('java.lang.String');
+        const str = new JavaString('test');
 
         expect(str.containsSyncSuffix).to.be.a('function');
         expect(str.containsSyncSuffix('e')).to.equal(true);
     });
 
     it('set invalid suffix', () => {
-        const error = 'syncSuffix and asyncSuffix cannot be the same';
-        expect(() => (config.asyncSuffix = 'Sync')).to.throw(error);
+        expect(() => (config.asyncSuffix = 'Sync')).to.throw(SUFFIX_ERROR);
 
         config.asyncSuffix = null;
-        expect(() => (config.syncSuffix = null)).to.throw(error);
-        expect(() => (config.syncSuffix = '')).to.throw(error);
+        expect(() => (config.syncSuffix = null)).to.throw(SUFFIX_ERROR);
+        expect(() => (config.syncSuffix = '')).to.throw(SUFFIX_ERROR);
 
         config.asyncSuffix = 'Async';
         config.syncSuffix = '';
 
-        expect(() => (config.asyncSuffix = '')).to.throw(error);
-        expect(() => (config.asyncSuffix = null)).to.throw(error);
+        expect(() => (config.asyncSuffix = '')).to.throw(SUFFIX_ERROR);
+        expect(() => (config.asyncSuffix = null)).to.throw(SUFFIX_ERROR);
+    });
+
+    it('set complete config', async () => {
+        config.config = {
+            runEventLoopWhenInterfaceProxyIsActive: false,
+            customInspect: true,
+            asyncSuffix: 'Async',
+            syncSuffix: 'Sync',
+        };
+
+        expect(config.runEventLoopWhenInterfaceProxyIsActive).to.be.false;
+        expect(config.customInspect).to.be.true;
+        expect(config.asyncSuffix).to.equal('Async');
+        expect(config.syncSuffix).to.equal('Sync');
+
+        const JavaString = importClass('java.lang.String');
+        const str = new JavaString('test');
+
+        expect(str.containsAsync).to.be.a('function');
+        const res = str.containsAsync('e');
+        expect(res).to.be.a('promise');
+        expect(await res).to.equal(true);
+
+        expect(str.containsSync).to.be.a('function');
+        expect(str.containsSync('e')).to.equal(true);
+    });
+
+    it('set invalid config', () => {
+        expect(() => {
+            config.config = {
+                runEventLoopWhenInterfaceProxyIsActive: false,
+                customInspect: true,
+                asyncSuffix: 'Sync',
+                syncSuffix: 'Sync',
+            };
+        }).to.throw(SUFFIX_ERROR);
+
+        expect(() => {
+            config.config = {
+                runEventLoopWhenInterfaceProxyIsActive: false,
+                customInspect: true,
+                asyncSuffix: '',
+                syncSuffix: '',
+            };
+        }).to.throw(SUFFIX_ERROR);
+
+        expect(() => {
+            config.config = {
+                runEventLoopWhenInterfaceProxyIsActive: false,
+                customInspect: true,
+                asyncSuffix: undefined,
+                syncSuffix: undefined,
+            };
+        }).to.throw(SUFFIX_ERROR);
+    });
+
+    it('import class with config', async () => {
+        const JavaString = importClass<typeof JString>('java.lang.String');
+        const str = new JavaString('test');
+
+        expect(str.toCharArray).to.be.a('function');
+        expect(str.toCharArraySync).to.be.a('function');
+
+        const res = str.toCharArray();
+        expect(res).to.be.a('promise');
+        expect(await res).to.deep.equal(['t', 'e', 's', 't']);
+        expect(str.toCharArraySync()).to.deep.equal(['t', 'e', 's', 't']);
+
+        const JavaStr = importClass('java.lang.String', {
+            asyncSuffix: 'Async',
+            syncSuffix: 'Sync',
+        });
+
+        const s = new JavaStr('test');
+
+        expect(s.toCharArrayAsync).to.be.a('function');
+        expect(s.toCharArraySync).to.be.a('function');
+
+        const res2 = s.toCharArrayAsync();
+        expect(res2).to.be.a('promise');
+        expect(await res2).to.deep.equal(['t', 'e', 's', 't']);
+        expect(s.toCharArraySync()).to.deep.equal(['t', 'e', 's', 't']);
+
+        const JavaStr2 = await importClassAsync<typeof JString>(
+            'java.lang.String'
+        );
+        const s2 = new JavaStr2('test');
+
+        expect(s2.toCharArray).to.be.a('function');
+        expect(s2.toCharArraySync).to.be.a('function');
+
+        const res3 = s2.toCharArray();
+        expect(res3).to.be.a('promise');
+        expect(await res3).to.deep.equal(['t', 'e', 's', 't']);
+        expect(s2.toCharArraySync()).to.deep.equal(['t', 'e', 's', 't']);
+    });
+
+    it('import class with config and invalid suffix', () => {
+        expect(() =>
+            importClass('java.lang.String', {
+                asyncSuffix: 'Sync',
+                syncSuffix: 'Sync',
+            })
+        ).to.throw(SUFFIX_ERROR);
+
+        expect(() =>
+            importClass('java.lang.String', {
+                asyncSuffix: '',
+                syncSuffix: '',
+            })
+        ).to.throw(SUFFIX_ERROR);
     });
 });

--- a/test/ProxyTest.test.ts
+++ b/test/ProxyTest.test.ts
@@ -94,6 +94,7 @@ describe('ProxyTest', () => {
         let proxy: JavaInterfaceProxy | null = null;
 
         before(() => {
+            java.clearClassProxies();
             java.config.runEventLoopWhenInterfaceProxyIsActive = true;
         });
 

--- a/test/StringTest.test.ts
+++ b/test/StringTest.test.ts
@@ -3,34 +3,12 @@ import {
     importClass,
     importClassAsync,
     ensureJvm,
-    JavaClass,
     config,
     clearClassProxies,
 } from '../.';
 import { expect } from 'chai';
 import { inspect } from 'util';
-
-declare class JString extends JavaClass {
-    constructor(value: string);
-
-    static newInstanceAsync(value: string): Promise<JString>;
-
-    static valueOf(values: string[]): Promise<JString>;
-
-    static valueOfSync(values: string[]): JString;
-
-    equals(other: JString): Promise<boolean>;
-
-    equalsSync(other: JString): boolean;
-
-    toCharArraySync(): string[];
-
-    toCharArray(): Promise<string[]>;
-
-    getBytesSync(): Buffer;
-
-    splitSync(regex: string): string[];
-}
+import { JString } from './classes';
 
 describe('StringTest', () => {
     it('Ensure jvm', () => {

--- a/test/StringTest.test.ts
+++ b/test/StringTest.test.ts
@@ -5,6 +5,7 @@ import {
     ensureJvm,
     JavaClass,
     config,
+    clearClassProxies,
 } from '../.';
 import { expect } from 'chai';
 import { inspect } from 'util';
@@ -147,6 +148,7 @@ describe('StringTest', () => {
     });
 
     it('inspect.custom', () => {
+        clearClassProxies();
         config.customInspect = true;
         const LoggableString = importClass<typeof JString>('java.lang.String');
         const str = new LoggableString('test');

--- a/test/classes.d.ts
+++ b/test/classes.d.ts
@@ -1,0 +1,23 @@
+import type { JavaClass } from '../ts-src';
+
+export declare class JString extends JavaClass {
+    constructor(value: string);
+
+    static newInstanceAsync(value: string): Promise<JString>;
+
+    static [`valueOf`](values: string[]): Promise<JString>;
+
+    static [`valueOfSync`](values: string[]): JString;
+
+    equals(other: JString): Promise<boolean>;
+
+    equalsSync(other: JString): boolean;
+
+    toCharArraySync(): string[];
+
+    toCharArray(): Promise<string[]>;
+
+    getBytesSync(): Buffer;
+
+    splitSync(regex: string): string[];
+}

--- a/ts-src/definitions.ts
+++ b/ts-src/definitions.ts
@@ -217,7 +217,7 @@ export declare class JavaClass extends JavaObject {
     /**
      * Custom inspect method for an improved console.log output.
      * This will return the output of {@link toString}.
-     * Will only be defined if {@link config.customInspect} is true.
+     * Will only be defined if {@link JavaConfig.customInspect} is true.
      *
      * @since 2.4.0
      * @returns this as a string

--- a/ts-src/index.ts
+++ b/ts-src/index.ts
@@ -26,3 +26,4 @@ import * as java from './java';
 export default java;
 export { getJavaLibPath, InterfaceProxyOptions } from '../native';
 export { getJavaVersion, getJavaVersionSync } from './util';
+export type { JavaConfig } from '../native';

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -234,6 +234,15 @@ export function importClassAsync<
 }
 
 /**
+ * Clear the class proxy cache.
+ * Use this method in order to reset the config for all class proxies.
+ * The new config will be applied once the class is imported again.
+ */
+export function clearClassProxies() {
+    Java.clearClassProxies();
+}
+
+/**
  * Append a single or multiple jars to the class path.
  *
  * Just replaces the old internal class loader with a new one containing the new jars.
@@ -768,7 +777,11 @@ export function getJavaInstance(): Java | null {
 /**
  * Configuration options for the java bridge.
  */
-export class config {
+export abstract class config {
+    private constructor() {
+        throw new Error('This class cannot be instantiated');
+    }
+
     /**
      * **Experimental Feature**
      *
@@ -820,5 +833,25 @@ export class config {
      */
     static get customInspect(): boolean {
         return JavaConfig.getCustomInspect();
+    }
+
+    static set syncSuffix(value: string | null) {
+        JavaConfig.setSyncSuffix(value);
+    }
+
+    static get syncSuffix(): string | null {
+        return JavaConfig.getSyncSuffix();
+    }
+
+    static set asyncSuffix(value: string | null) {
+        JavaConfig.setAsyncSuffix(value);
+    }
+
+    static get asyncSuffix(): string | null {
+        return JavaConfig.getAsyncSuffix();
+    }
+
+    static reset(): void {
+        JavaConfig.reset();
     }
 }

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -4,7 +4,6 @@ import {
     JavaOptions,
     JavaConfig,
     ClassConfiguration,
-    Config,
 } from '../native';
 import {
     JavaClass,
@@ -691,7 +690,7 @@ export type AnyProxyRecord = Record<string, ProxyMethod>;
  *
  * If you still want to call everything in a synchronous manner, make sure to enable
  * running the event loop while waiting for a java method to return by setting
- * {@link config.runEventLoopWhenInterfaceProxyIsActive} to true.
+ * {@link JavaConfig.runEventLoopWhenInterfaceProxyIsActive} to true.
  * **This may cause application crashes, so it is strongly recommended to just use async methods.**
  *
  * ### Keeping the proxy alive
@@ -758,7 +757,8 @@ export function newProxy<T extends ProxyRecord<T> = AnyProxyRecord>(
             try {
                 const res = (method as ProxyMethod)(...args);
                 if (res instanceof Promise) {
-                    res.then((res: unknown) => callback(null, res)).catch(
+                    res.then(
+                        (res: unknown) => callback(null, res),
                         (e: unknown) => {
                             if (e instanceof Error) {
                                 callback(e);
@@ -796,169 +796,6 @@ export function getJavaInstance(): Java | null {
 }
 
 /**
- * Configuration options for the java bridge.
- *
- * @since 2.2.3
+ * @inheritDoc JavaConfig
  */
-export abstract class config {
-    private constructor() {
-        throw new Error('This class cannot be instantiated');
-    }
-
-    /**
-     * **Experimental Feature**
-     *
-     * Set whether to run the event loop when an interface proxy is active.
-     * This is disabled by default. Enabling this will cause the bridge
-     * to run the event loop when an interface proxy either as direct
-     * proxy or as daemon proxy is active. This is only required if the
-     * proxied method calls back into the javascript process in the same thread.
-     * If the proxy is used either in an async method or in a different thread,
-     * this is not required.
-     *
-     * **Note:** Enabling this may cause the application to crash. Use with caution.
-     *
-     * @since 2.2.3
-     * @experimental
-     * @param value whether to run the event loop when an interface proxy is active
-     */
-    static set runEventLoopWhenInterfaceProxyIsActive(value: boolean) {
-        JavaConfig.setRunEventLoopWhenInterfaceProxyIsActive(value);
-    }
-
-    /**
-     * **Experimental Feature**
-     *
-     * Get whether to run the event loop when an interface proxy is active.
-     * @since 2.2.3
-     * @experimental
-     */
-    static get runEventLoopWhenInterfaceProxyIsActive(): boolean {
-        return JavaConfig.getRunEventLoopWhenInterfaceProxyIsActive();
-    }
-
-    /**
-     * Whether to add custom inspect methods to java objects.
-     * This is disabled by default.
-     * This allows console.log to print java objects in a more readable way
-     * using the `toString` method of the java object.
-     *
-     * @since 2.4.0
-     * @param value whether to add custom inspect methods to java objects
-     */
-    static set customInspect(value: boolean) {
-        JavaConfig.setCustomInspect(value);
-    }
-
-    /**
-     * Get whether to add custom inspect methods to java objects.
-     *
-     * @since 2.4.0
-     * @returns whether to add custom inspect methods to java objects
-     */
-    static get customInspect(): boolean {
-        return JavaConfig.getCustomInspect();
-    }
-
-    /**
-     * Set the suffix for synchronous methods.
-     * This is `Sync` by default.
-     * Pass `null` or an empty string to disable the suffix.
-     * This must not be the same as the {@link asyncSuffix}.
-     *
-     * # Example
-     * ```ts
-     * import { config, clearClassProxies } from 'java-bridge';
-     *
-     * // Set the async suffix in order to prevent errors
-     * config.asyncSuffix = 'Async';
-     * // Set the sync suffix to an empty string
-     * config.syncSuffix = '';
-     * // This would do the same
-     * config.syncSuffix = null;
-     *
-     * // Clear the class proxy cache
-     * clearClassProxies();
-     *
-     * // Import the class
-     * const ArrayList = importClass('java.util.ArrayList');
-     *
-     * // Create a new instance
-     * const list = new ArrayList();
-     *
-     * // Call the method
-     * list.add('Hello World!');
-     *
-     * // Async methods now have the 'Async' suffix
-     * await list.addAsync('Hello World!');
-     * ```
-     *
-     * @see asyncSuffix
-     * @since 2.4.0
-     * @param value the suffix to use for synchronous methods
-     */
-    static set syncSuffix(value: string | null) {
-        JavaConfig.setSyncSuffix(value);
-    }
-
-    /**
-     * Get the suffix for synchronous methods.
-     *
-     * @since 2.4.0
-     */
-    static get syncSuffix(): string | null {
-        return JavaConfig.getSyncSuffix();
-    }
-
-    /**
-     * Set the suffix for asynchronous methods.
-     * This is `Async` by default.
-     * Pass `null` or an empty string to disable the suffix.
-     * This must not be the same as the {@link syncSuffix}.
-     *
-     * @see syncSuffix
-     * @since 2.4.0
-     * @param value the suffix to use for asynchronous methods
-     */
-    static set asyncSuffix(value: string | null) {
-        JavaConfig.setAsyncSuffix(value);
-    }
-
-    /**
-     * Get the suffix for asynchronous methods.
-     *
-     * @since 2.4.0
-     */
-    static get asyncSuffix(): string | null {
-        return JavaConfig.getAsyncSuffix();
-    }
-
-    /**
-     * Override the whole config.
-     * If you want to change only a single field, use the static setters instead.
-     *
-     * @since 2.4.0
-     * @param config the config to use
-     */
-    static set config(config: Config) {
-        JavaConfig.set(config);
-    }
-
-    /**
-     * Get the current config.
-     *
-     * @since 2.4.0
-     */
-    static get config(): Config {
-        return JavaConfig.get();
-    }
-
-    /**
-     * Reset the config to the default values.
-     *
-     * @since 2.4.0
-     */
-    static reset(): void {
-        JavaConfig.reset();
-    }
-}
+export const config = new JavaConfig();


### PR DESCRIPTION
Added config options, which allow to set the suffixes for sync and async methods.

## Example

```ts
import { config, importClass } from 'java-bridge';

config.syncSuffix = 'SyncSuffix';

const JavaString = importClass('java.lang.String');
const str = new JavaString('test');

str.containsSyncSuffix('e'); // true
```

Temporary configurations can be passed to the `importClass` method:
```ts
import { importClass } from 'java-bridge';

const JavaString = importClass('java.lang.String', {
  syncSuffix: 'SyncSuffix',
});

const str = new JavaString('test');

str.containsSyncSuffix('e'); // true
```