### PR TITLE
fix(bridge): add a toString method to all objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "rand",
  "serde",
  "smart-default",
+ "spin_sleep",
  "tokio",
 ]
 
@@ -945,6 +946,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.23",
+]
+
+[[package]]
+name = "spin_sleep"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cafa7900db085f4354dbc7025e25d7a839a14360ea13b5fc4fd717f2d3b23134"
+dependencies = [
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/java-bridge/Cargo.toml
+++ b/crates/java-bridge/Cargo.toml
@@ -32,6 +32,7 @@ log = { version = "0.4", optional = true }
 log4rs = { version = "1.2", features = ["json_format"], optional = true }
 serde = { version = "1.0", optional = true }
 smart-default = "0.7.1"
+spin_sleep = "1.1.1"
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/crates/java-bridge/src/node/interface_proxy/java_interface_proxy.rs
+++ b/crates/java-bridge/src/node/interface_proxy/java_interface_proxy.rs
@@ -188,7 +188,7 @@ impl JavaInterfaceProxy {
         let string = JavaClass::by_name("java/lang/String", &j_env)?;
         let mut implemented_methods = JavaObjectArray::new(&string, methods.len())?;
         for i in 0..methods.len() {
-            let str = JavaString::from_string(methods.keys().nth(i).unwrap().into(), &j_env)?;
+            let str = JavaString::from_string(methods.keys().nth(i).unwrap().to_string(), &j_env)?;
             implemented_methods.set(i as _, Some(JavaObject::from(str)))?;
         }
 

--- a/crates/java-bridge/src/node/java_class_instance.rs
+++ b/crates/java-bridge/src/node/java_class_instance.rs
@@ -369,7 +369,7 @@ impl JavaClassInstance {
                     uv_run(ctx.env.get_uv_event_loop()?, uv_run_mode::UV_RUN_NOWAIT);
                 }
 
-                thread::sleep(Duration::from_millis(10));
+                spin_sleep::sleep(Duration::from_micros(1));
             }
 
             handle

--- a/crates/java-rs/src/java/java_env_wrapper.rs
+++ b/crates/java-rs/src/java/java_env_wrapper.rs
@@ -35,6 +35,7 @@ use crate::{
 use std::borrow::Borrow;
 use std::error::Error;
 use std::ffi::{CStr, CString};
+use std::fmt::Display;
 use std::ops::Not;
 use std::ptr;
 use std::sync::{Arc, Mutex};
@@ -1302,7 +1303,10 @@ impl<'a> JavaEnvWrapper<'a> {
         Ok(converted?)
     }
 
-    pub fn string_to_java_string(&'a self, string: String) -> ResultType<JavaString<'a>> {
+    pub fn string_to_java_string<T: Into<Vec<u8>> + Display>(
+        &'a self,
+        string: T,
+    ) -> ResultType<JavaString<'a>> {
         crate::trace!("Converting '{}' to java string", string);
 
         let c_string = CString::new(string)?;

--- a/crates/java-rs/src/java/java_type.rs
+++ b/crates/java-rs/src/java/java_type.rs
@@ -419,6 +419,10 @@ impl JavaType {
             || self.type_enum() == Type::Double
     }
 
+    pub fn is_string(&self) -> bool {
+        self.type_enum() == Type::String
+    }
+
     pub fn as_class<'a>(&self, env: &'a JavaEnv<'a>) -> ResultType<JavaClass<'a>> {
         let class_name = match self.type_enum {
             Type::Void => "java.lang.Void",

--- a/crates/java-rs/src/java/objects/string.rs
+++ b/crates/java-rs/src/java/objects/string.rs
@@ -9,6 +9,7 @@ use crate::java_type::Type;
 use crate::objects::java_object::{AsJavaObject, JavaObject};
 use crate::sys;
 use std::error::Error;
+use std::fmt::Display;
 
 pub struct JavaString<'a>(pub(in crate::java::objects) LocalJavaObject<'a>);
 
@@ -29,7 +30,10 @@ impl<'a> JavaString<'a> {
         env.string_to_java_string(string)
     }
 
-    pub fn from_string(string: String, env: &'a JavaEnv<'a>) -> ResultType<Self> {
+    pub fn from_string<T: Into<Vec<u8>> + Display>(
+        string: T,
+        env: &'a JavaEnv<'a>,
+    ) -> ResultType<Self> {
         env.get_env().string_to_java_string(string)
     }
 

--- a/crates/java-rs/src/tests/signature_tests.rs
+++ b/crates/java-rs/src/tests/signature_tests.rs
@@ -111,8 +111,6 @@ fn method_call_with_invalid_args() {
         .get_static_object_method("valueOf", "(I)Ljava/lang/String;")
         .unwrap();
     method
-        .call(&[JavaString::from_string("hello".into(), &env)
-            .unwrap()
-            .as_arg()])
+        .call(&[JavaString::from_string("hello", &env).unwrap().as_arg()])
         .expect_err("Should have failed");
 }

--- a/ts-src/java.ts
+++ b/ts-src/java.ts
@@ -38,7 +38,6 @@ export interface JVMOptions extends JavaOptions {
     opts?: Array<string> | null;
     /**
      * Whether this runs inside a packaged electron app
-     * @deprecated this option is not needed anymore and will be removed in a future version
      */
     isPackagedElectron?: boolean;
 }


### PR DESCRIPTION
Some methods do not have a proper `toString` method, thus this method isn't added to the node objects. This PR adds the default `toString` method of `java.lang.Object` to all objects, which currently don't have a custom implementation of that method.