### PR TITLE
java.lang.OutOfMemoryError: Java heap space

### DIFF
--- a/test/MemorySafe.test.ts
+++ b/test/MemorySafe.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { importClass, ensureJvm } from '../.';
+
+ensureJvm({
+    opts: [
+        '-Xms512m', 
+        '-Xmx512m'
+    ],
+})
+
+describe('MemorySafe tests', () => {
+    it('should allow 1000 instances of java.io.ByteArrayInputStream', () => {
+        const ByteArrayInputStream = importClass('java.io.ByteArrayInputStream');
+        const buffer = Buffer.alloc(1024 * 1024);
+
+        for (let i = 0; i < 200000; i++) {
+            const stream = new ByteArrayInputStream(buffer);
+            expect(stream).to.be.an('object');
+        }
+    })
+})


### PR DESCRIPTION
Hi there, first of all, thank you for this library. It really is the best node/java library available!

However, I have hit an issue related to memory that I don't know enough about how the JVM/Rust works to solve. As can be seen in the PR, i've created a test to show the error I'm getting when repeatedly allocating memory. It gets to about iteration ~500 and then comes out with `java.lang.OutOfMemoryError: Java heap space`. Perhaps there is a memory leak somewhere?

If it helps, I'm running Ubuntu 22.04