### PR TITLE
feat(bridge): return java throwable to node process

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,31 +1,33 @@
 name: Check-style
 on:
-    push:
-        branches:
-            - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    check-ts-style:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Setup Node.js environment
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 20.x
-            - name: Install dependencies
-              run: npm i -D
-            - name: Prettier check
-              run: npm run prettier:check
+  check-ts-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Install dependencies
+        run: npm i -D
+      - name: Prettier check
+        run: npm run prettier:check
 
-    check-rust-style:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Check style
-              run: cargo fmt -- --check
+  check-rust-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,33 +1,33 @@
 name: Check-style
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+    push:
+        branches:
+            - main
+    pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  check-ts-style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-      - name: Install dependencies
-        run: npm i -D
-      - name: Prettier check
-        run: npm run prettier:check
+    check-ts-style:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20.x
+            - name: Install dependencies
+              run: npm i -D
+            - name: Prettier check
+              run: npm run prettier:check
 
-  check-rust-style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check format
-        run: cargo fmt --all -- --check
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+    check-rust-style:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Check format
+              run: cargo fmt --all -- --check
+            - name: Clippy
+              run: cargo clippy --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 <!--[![SystemTest](https://github.com/MarkusJx/node-java-bridge/actions/workflows/system_test.yml/badge.svg)](https://github.com/MarkusJx/node-java-bridge/actions/workflows/system_test.yml)-->
 
-A bridge between Node.js programs and Java APIs written in Rust using [napi-rs](https://napi.rs/)
+A bridge between Node.js programs and Java APIs written in Rust
+using [napi-rs](https://napi.rs/)
 to provide a fast and memory-safe interface between the two languages.
 
 The pre-compiled binaries will be provided with the package, the only thing
@@ -14,9 +15,11 @@ for this package to use. In contrast to other `node.js <-> java` interfaces,
 the binary is not hard linked to the JDK it has been compiled with but rather
 loads the jvm native library dynamically when the program first starts up.
 
-The full documentation of this package is available [here](https://markusjx.github.io/node-java-bridge/).
+The full documentation of this package is
+available [here](https://markusjx.github.io/node-java-bridge/).
 
-**NOTE: As of version `2.1.0`, this package has been renamed from `@markusjx/java` to `java-bridge`.**
+**NOTE: As of version `2.1.0`, this package has been renamed from `@markusjx/java`
+to `java-bridge`.**
 
 ## Installation
 
@@ -24,17 +27,22 @@ The full documentation of this package is available [here](https://markusjx.gith
 npm i java-bridge
 ```
 
-_Note: In order to use this package on windows, you'll need to install the [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-gb/download/details.aspx?id=48145)._
+_Note: In order to use this package on windows, you'll need to install
+the [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-gb/download/details.aspx?id=48145)._
 
 ## Command line interface
 
-This module also provides a command line interface that allows you to generate typescript definitions for your java classes.
-The command line interface is called `java-ts-definition-generator` and can be installed using `npm install -g java-ts-definition-generator`.
-The full documentation can be found [here](https://github.com/MarkusJx/java-ts-definition-generator).
+This module also provides a command line interface that allows you to generate typescript
+definitions for your java classes.
+The command line interface is called `java-ts-definition-generator` and can be installed
+using `npm install -g java-ts-definition-generator`.
+The full documentation can be
+found [here](https://github.com/MarkusJx/java-ts-definition-generator).
 
 ## Build instructions
 
-_This is only required for development purposes. When installing the package using `npm i`, you can skip this._
+_This is only required for development purposes. When installing the package
+using `npm i`, you can skip this._
 
 In order to build this project, you should install
 
@@ -54,7 +62,8 @@ npm run build
 
 ## Support Matrix
 
-> _✅ = Pre-compiled binaries are available_<br> _`-` = Pre-compiled binaries are not available_
+> _✅ = Pre-compiled binaries are available_<br> _`-` = Pre-compiled binaries are not
+> available_
 
 | Operating System | i686 | x64 | arm | arm64 |
 | ---------------- | :--: | :-: | :-: | :---: |
@@ -82,7 +91,9 @@ System.out.println('Hello world!');
 
 ### Create the JVM
 
-Create a new Java VM using the [`ensureJvm`](https://markusjx.github.io/node-java-bridge/functions/ensureJvm.html) method.
+Create a new Java VM using
+the [`ensureJvm`](https://markusjx.github.io/node-java-bridge/functions/ensureJvm.html)
+method.
 Calling this after the jvm has already been created will do nothing.
 Destroying the jvm manually is not (yet) supported.
 
@@ -100,8 +111,10 @@ ensureJvm();
 
 #### Create the JVM with extra options
 
-You can pass extra options to the jvm when creating it, for example requesting a specific jvm version,
-specifying the location of the jvm native library or passing additional arguments to the jvm.
+You can pass extra options to the jvm when creating it, for example requesting a specific
+jvm version,
+specifying the location of the jvm native library or passing additional arguments to the
+jvm.
 
 ```ts
 import { ensureJvm, JavaVersion } from 'java-bridge';
@@ -113,15 +126,18 @@ ensureJvm({
 });
 ```
 
-All threads will be attached as daemon threads, allowing the jvm to exit when the main thread exits.
+All threads will be attached as daemon threads, allowing the jvm to exit when the main
+thread exits.
 This behaviour can not be changed, as it may introduce undefined behaviour.
 
-Important note on jvm options: Different arguments must be parsed as separate strings in the `opts` array.
+Important note on jvm options: Different arguments must be parsed as separate strings in
+the `opts` array.
 Otherwise, the jvm will not be able to parse the arguments correctly.
 
 #### Notes on electron
 
-When using this package in a packaged electron application, you should unpack this package and
+When using this package in a packaged electron application, you should unpack this package
+and
 the appropriate binaries for your platform into the `app.asar.unpacked` folder. When using
 electron-builder, you can do this by adding the following to your `package.json`:
 
@@ -136,7 +152,8 @@ electron-builder, you can do this by adding the following to your `package.json`
 }
 ```
 
-Additionally, you should set the `isPackagedElectron` option to `true` when creating the jvm:
+Additionally, you should set the `isPackagedElectron` option to `true` when creating the
+jvm:
 
 ```ts
 ensureJvm({
@@ -144,7 +161,8 @@ ensureJvm({
 });
 ```
 
-This option _should_ not have any effect when not using electron or not having the application packaged.
+This option _should_ not have any effect when not using electron or not having the
+application packaged.
 
 ### Inject a JAR into the class path
 
@@ -153,7 +171,8 @@ to add the JAR file to the class path. You can do that with the
 [`appendClasspath`](https://markusjx.github.io/node-java-bridge/functions/appendClasspath.html)
 or [`classpath.append`](https://markusjx.github.io/node-java-bridge/functions/classpath.append.html)
 methods. After loading a JAR, you can import classes from it like any other class
-from the JVM using [`importClass`](#synchronous-calls) or [`importClassAsync`](#asynchronous-calls).
+from the JVM using [`importClass`](#synchronous-calls)
+or [`importClassAsync`](#asynchronous-calls).
 
 ```ts
 import { appendClasspath } from 'java-bridge';
@@ -176,9 +195,11 @@ classpath.append('/path/to/jar.jar');
 
 ### Synchronous calls
 
-If you want to use Java APIs in a synchronous way, you can use the synchronous API of this module.
+If you want to use Java APIs in a synchronous way, you can use the synchronous API of this
+module.
 Any call to the Java API will be executed in the same thread as your node process so this
-may cause your program to hang until the execution is finished. But - in contrast to the asynchronous API -
+may cause your program to hang until the execution is finished. But - in contrast to the
+asynchronous API -
 these calls are a lot faster as no extra threads need to be created/attached to the JVM.
 
 All synchronous java methods are proceeded with the postfix `Sync`.
@@ -186,8 +207,11 @@ This means, all methods of a class (static and non-static) are generated twice,
 once as a synchronous call and once as an asynchronous call.
 
 If you are looking for asynchronous calls, take a look at the next section.
-In order to import a class synchronously, you can use the [`importClass`](https://markusjx.github.io/node-java-bridge/functions/importClass.html) function.
-Using this method does not affect your ability to call any method of the class asynchronously.
+In order to import a class synchronously, you can use
+the [`importClass`](https://markusjx.github.io/node-java-bridge/functions/importClass.html)
+function.
+Using this method does not affect your ability to call any method of the class
+asynchronously.
 
 ```ts
 import { importClass } from 'java-bridge';
@@ -208,16 +232,22 @@ str.toStringSync(); // 'Hello World'
 
 ### Asynchronous calls
 
-If you want to use Java APIs in an asynchronous way, you can use the asynchronous API of this module.
-Any call to the Java API will be executed in a separate thread and the execution will not block your program.
-This is in general a lot slower as the synchronous API but allows the program to run more smoothly.
+If you want to use Java APIs in an asynchronous way, you can use the asynchronous API of
+this module.
+Any call to the Java API will be executed in a separate thread and the execution will not
+block your program.
+This is in general a lot slower as the synchronous API but allows the program to run more
+smoothly.
 
-If you want to improve the performance of the asynchronous API, you can force the module to attach
-any thread as a daemon thread to the JVM. This allows the program to not constantly attach new threads
+If you want to improve the performance of the asynchronous API, you can force the module
+to attach
+any thread as a daemon thread to the JVM. This allows the program to not constantly attach
+new threads
 to the JVM as the old ones can be reused and thus improves the performance.
 
 In order to import a class asynchronously, you can use the
-[`importClassAsync`](https://markusjx.github.io/node-java-bridge/functions/importClassAsync.html) function.
+[`importClassAsync`](https://markusjx.github.io/node-java-bridge/functions/importClassAsync.html)
+function.
 
 ```ts
 import { importClassAsync } from 'java-bridge';
@@ -238,7 +268,8 @@ You can also implement a Java interface in node.js using the
 [`newProxy`](https://markusjx.github.io/node-java-bridge/functions/newProxy.html) method.
 Please note that when calling a java method that uses an interface defined by this method,
 you must call that method using the interface asynchronously as Node.js is single threaded
-and can't wait for the java method to return while calling the proxy method at the same time.
+and can't wait for the java method to return while calling the proxy method at the same
+time.
 
 ```ts
 import { newProxy } from 'java-bridge';
@@ -274,6 +305,28 @@ const guard = stdout.enableRedirect(
 );
 ```
 
+## Errors
+
+Errors thrown in the java process are returned as `JavaError` objects.
+These objects contain the error message, the full stack trace (including the java, node
+and rust process) and the java throwable that caused
+the error. The throwable is only available when the error was thrown in the java process
+and not in the node process and if the call was a synchronous call. Async calls will not
+return the throwable. The throwable can be accessed using the `cause` property of the
+`JavaError` object.
+
+```ts
+import type { JavaError } from 'java-bridge';
+
+try {
+    // Call a method that throws an error
+    someInstance.someMethodSync();
+} catch (e: unknown) {
+    const throwable = (e as JavaError).cause;
+    throwable.printStackTraceSync();
+}
+```
+
 ## Logging
 
 If you want to enable logging for this module, you need to re-compile the module
@@ -296,22 +349,30 @@ For further information on how to use the logging feature, please take a look at
 
 ## Value conversion rules
 
-1. Any basic value such as `string`, `number`, `boolean` or `BigInt` may be passed to methods accepting matching
+1. Any basic value such as `string`, `number`, `boolean` or `BigInt` may be passed to
+   methods accepting matching
    types
 2. `string` values will always be converted to `java.lang.String`
-3. `string` values with just one character may be converted to `char` or `java.lang.Char` if required
-4. Thus, in order to pass a `char` to a java method, use a `string` containing just one character
-5. `number` values will be converted to `int`, `long`, `double`, `float`, `java.lang.Integer`,
-   `java.lang.Long`, `java.lang.Double` or `java.lang.Float` depending on the type the java function to call requires
+3. `string` values with just one character may be converted to `char` or `java.lang.Char`
+   if required
+4. Thus, in order to pass a `char` to a java method, use a `string` containing just one
+   character
+5. `number` values will be converted
+   to `int`, `long`, `double`, `float`, `java.lang.Integer`,
+   `java.lang.Long`, `java.lang.Double` or `java.lang.Float` depending on the type the
+   java function to call requires
 6. `boolean` values will be converted to either `boolean` or `java.lang.Boolean`
 7. `BigInt` values will be converted to either `long` or `java.lang.Long`
-8. Arrays will be converted to java arrays. Java arrays may only contain a single value type, therefore the type of
-   the first element in the array will be chosen as the array type, empty arrays need no conversions.
+8. Arrays will be converted to java arrays. Java arrays may only contain a single value
+   type, therefore the type of
+   the first element in the array will be chosen as the array type, empty arrays need no
+   conversions.
 9. `java.lang.String` values will be converted to `string`
 10. `int`, `double`, `float`, `java.lang.Integer`, `java.lang.Double` or `java.lang.Float`
     values will be converted to `number`
 11. `long` or `java.lang.Long` values will always be converted to `BigInt`
 12. `boolean` or `java.lang.Boolean` values will be converted to `boolean`
 13. `char` or `java.lang.Character` values will be converted to `string`
-14. Java arrays will be converted to javascript arrays, applying the rules mentioned above except
+14. Java arrays will be converted to javascript arrays, applying the rules mentioned above
+    except
 15. Byte arrays will be converted to `Buffer` and vice-versa

--- a/README.md
+++ b/README.md
@@ -311,8 +311,9 @@ Errors thrown in the java process are returned as `JavaError` objects.
 These objects contain the error message, the full stack trace (including the java, node
 and rust process) and the java throwable that caused
 the error. The throwable is only available when the error was thrown in the java process
-and not in the node process and if the call was a synchronous call. Async calls will not
-return the throwable. The throwable can be accessed using the `cause` property of the
+and not in the node process and if the call was a synchronous call.
+
+The throwable can be accessed using the `cause` property of the
 `JavaError` object.
 
 ```ts
@@ -321,6 +322,26 @@ import type { JavaError } from 'java-bridge';
 try {
     // Call a method that throws an error
     someInstance.someMethodSync();
+} catch (e: unknown) {
+    const throwable = (e as JavaError).cause;
+    throwable.printStackTraceSync();
+}
+```
+
+If you want to access the Java throwable from an asynchronous call, you
+need to enable
+the `asyncJavaExceptionObjects` [config option](https://markusjx.github.io/node-java-bridge/variables/config.html)
+before or while importing the class.
+
+```ts
+import { importClass } from 'java-bridge';
+
+const SomeClass = importClass('path.to.SomeClass', {
+    asyncJavaExceptionObjects: true,
+});
+
+try {
+    await SomeClass.someMethod();
 } catch (e: unknown) {
     const throwable = (e as JavaError).cause;
     throwable.printStackTraceSync();

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ If you want to access the Java throwable from an asynchronous call, you
 need to enable
 the `asyncJavaExceptionObjects` [config option](https://markusjx.github.io/node-java-bridge/variables/config.html)
 before or while importing the class.
+Enabling this will cause the stack trace of the JavaScript error to be lost.
 
 ```ts
 import { importClass } from 'java-bridge';

--- a/crates/java-bridge/src/java/class_constructor.rs
+++ b/crates/java-bridge/src/java/class_constructor.rs
@@ -1,4 +1,4 @@
-use crate::node::util::util::ResultType;
+use crate::node::util::helpers::ResultType;
 use java_rs::java_env::JavaEnv;
 use java_rs::java_type::JavaType;
 use java_rs::java_vm::JavaVM;
@@ -74,7 +74,7 @@ impl ClassConstructor {
         let mut parameter_types: Vec<JavaType> = vec![];
         for i in 0..num_parameters {
             let parameter = parameter_to_type(
-                &env,
+                env,
                 &parameters.get(i)?.ok_or(
                     "A value in the array returned by Constructor.getParameters() was null"
                         .to_string(),

--- a/crates/java-bridge/src/java/class_field.rs
+++ b/crates/java-bridge/src/java/class_field.rs
@@ -9,7 +9,7 @@ use java_rs::objects::java_object::JavaObject;
 use java_rs::objects::object::{GlobalJavaObject, LocalJavaObject};
 use java_rs::objects::string::JavaString;
 use java_rs::util::conversion::{get_field_from_signature, get_field_type};
-use java_rs::util::util::{field_is_final, method_is_public, ResultType};
+use java_rs::util::helpers::{field_is_final, method_is_public, ResultType};
 use std::collections::HashMap;
 
 pub struct ClassField {
@@ -80,12 +80,12 @@ impl ClassField {
         field: LocalJavaObject,
         is_static: bool,
     ) -> ResultType<Self> {
-        let field_type = get_field_type(&env, &field)?;
+        let field_type = get_field_type(env, &field)?;
         Ok(ClassField {
             vm,
             name: name.clone(),
-            field: get_field_from_signature(&env, class_name, name, field_type, is_static)?,
-            is_final: field_is_final(&env, &field)?,
+            field: get_field_from_signature(env, class_name, name, field_type, is_static)?,
+            is_final: field_is_final(env, &field)?,
         })
     }
 

--- a/crates/java-bridge/src/java/class_method.rs
+++ b/crates/java-bridge/src/java/class_method.rs
@@ -18,7 +18,7 @@ use java_rs::objects::string::JavaString;
 use java_rs::util::conversion::{
     get_method_from_signature, get_method_name, get_method_parameters, get_method_return_type,
 };
-use java_rs::util::util::{method_is_public, ResultType};
+use java_rs::util::helpers::{method_is_public, ResultType};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
@@ -67,7 +67,7 @@ impl ClassMethod {
                 )?;
 
                 let method_name = method.name.clone();
-                res.entry(method_name).or_insert(vec![]).push(method);
+                res.entry(method_name).or_default().push(method);
             }
         }
 
@@ -75,11 +75,10 @@ impl ClassMethod {
         // default one from the java.lang.Object class.
         let to_string = res.get("toString");
         if to_string.is_none()
-            || to_string
+            || !to_string
                 .unwrap()
                 .iter()
-                .find(|m| m.parameter_types.is_empty() && m.return_type.is_string())
-                .is_none()
+                .any(|m| m.parameter_types.is_empty() && m.return_type.is_string())
         {
             let java_object = JavaClass::by_name("java/lang/Object", &env)?;
             let get_method = java_class
@@ -105,7 +104,7 @@ impl ClassMethod {
             )?;
 
             res.entry("toString".to_string())
-                .or_insert(vec![])
+                .or_default()
                 .push(to_string);
         }
 

--- a/crates/java-bridge/src/logging/dummies.rs
+++ b/crates/java-bridge/src/logging/dummies.rs
@@ -9,6 +9,7 @@ pub mod logging {
     use napi::JsUnknown;
     use std::sync::Once;
 
+    #[allow(unused)]
     fn warn_disabled() {
         static ONCE: Once = Once::new();
         ONCE.call_once(|| {
@@ -17,6 +18,7 @@ pub mod logging {
     }
 
     #[napi]
+    #[allow(unused)]
     /// This method is not supported in this build.
     /// It will print a warning to stderr when called.
     ///
@@ -29,6 +31,7 @@ pub mod logging {
     }
 
     #[napi]
+    #[allow(unused)]
     /// This method is not supported in this build.
     /// It will print a warning to stderr when called.
     ///
@@ -38,6 +41,7 @@ pub mod logging {
     }
 
     #[napi]
+    #[allow(unused)]
     /// This method is not supported in this build.
     /// It will print a warning to stderr when called.
     ///
@@ -47,6 +51,7 @@ pub mod logging {
     }
 
     #[napi]
+    #[allow(unused)]
     /// Whether logging is supported.
     /// Logging is disabled by default.
     /// This constant currently is set to `false`

--- a/crates/java-bridge/src/logging/macros.rs
+++ b/crates/java-bridge/src/logging/macros.rs
@@ -1,13 +1,13 @@
-#[cfg(feature = "log")]
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => {
+        #[cfg(feature = "log")]
         log::debug!($($arg)*);
     };
 }
 
-#[cfg(not(feature = "log"))]
+/*#[cfg(not(feature = "log"))]
 #[macro_export]
 macro_rules! debug {
     ($($arg:tt)*) => {};
-}
+}*/

--- a/crates/java-bridge/src/logging/writer.rs
+++ b/crates/java-bridge/src/logging/writer.rs
@@ -117,7 +117,7 @@ impl<'a> NodeWriter<'a> {
                     )
                     .collect(),
                 )
-                .map_napi_err()
+                .map_napi_err(None)
             })
             .map_or(Ok(None), |v| v.map(Some))
             .map_err(|e| io::Error::new(ErrorKind::Other, e))

--- a/crates/java-bridge/src/node/class_cache.rs
+++ b/crates/java-bridge/src/node/class_cache.rs
@@ -1,6 +1,6 @@
 use crate::node::config::{ClassConfiguration, Config};
 use crate::node::java_class_proxy::JavaClassProxy;
-use crate::node::util::util::ResultType;
+use crate::node::util::helpers::ResultType;
 use java_rs::java_vm::JavaVM;
 use java_rs::trace;
 use std::collections::HashMap;
@@ -34,7 +34,7 @@ impl ClassCache {
             Ok(proxy.clone())
         } else {
             if let Some(cfg) = config.as_ref() {
-                if !Config::get().eq(&cfg) {
+                if !Config::get().eq(cfg) {
                     return Ok(Arc::new(JavaClassProxy::new(
                         vm.clone(),
                         class_name.clone(),
@@ -51,6 +51,7 @@ impl ClassCache {
         }
     }
 
+    #[allow(unused)]
     pub fn clear(&mut self) {
         self.0.clear();
     }

--- a/crates/java-bridge/src/node/config.rs
+++ b/crates/java-bridge/src/node/config.rs
@@ -32,6 +32,14 @@ pub struct ClassConfiguration {
     /// Setting this value to the same value as syncSuffix will result in an error.
     /// If not specified, the value from the global configuration will be used.
     pub async_suffix: Option<String>,
+    /// If true, any Java exception will be returned in the `cause`
+    /// field of the thrown `JavaError` even in async methods.
+    /// Enabling this will cause the stack trace of the
+    /// JavaScript error to be lost.
+    /// If not specified, the value from the global configuration will be used.
+    ///
+    /// @since 2.6.0
+    pub async_java_exception_objects: Option<bool>,
 }
 
 impl TryFrom<ClassConfiguration> for Config {
@@ -61,6 +69,9 @@ impl TryFrom<ClassConfiguration> for Config {
             custom_inspect: value.custom_inspect.unwrap_or(config.custom_inspect),
             sync_suffix: value.sync_suffix.or(sync_suffix.cloned()),
             async_suffix: value.async_suffix.or(async_suffix.cloned()),
+            async_java_exception_objects: value
+                .async_java_exception_objects
+                .or(config.async_java_exception_objects),
         })
     }
 }
@@ -97,6 +108,15 @@ pub struct Config {
     /// @since 2.4.0
     #[default(None)]
     pub async_suffix: Option<String>,
+    /// If true, any Java exception will be returned in the `cause`
+    /// field of the thrown `JavaError` even in async methods.
+    /// Enabling this will cause the stack trace of the
+    /// JavaScript error to be lost.
+    /// Default is false.
+    ///
+    /// @since 2.6.0
+    #[default(None)]
+    pub async_java_exception_objects: Option<bool>,
 }
 
 impl Config {

--- a/crates/java-bridge/src/node/config.rs
+++ b/crates/java-bridge/src/node/config.rs
@@ -59,8 +59,8 @@ impl TryFrom<ClassConfiguration> for Config {
                 .run_event_loop_when_interface_proxy_is_active
                 .unwrap_or(config.run_event_loop_when_interface_proxy_is_active),
             custom_inspect: value.custom_inspect.unwrap_or(config.custom_inspect),
-            sync_suffix: value.sync_suffix.or(sync_suffix.map(|s| s.clone())),
-            async_suffix: value.async_suffix.or(async_suffix.map(|s| s.clone())),
+            sync_suffix: value.sync_suffix.or(sync_suffix.cloned()),
+            async_suffix: value.async_suffix.or(async_suffix.cloned()),
         })
     }
 }

--- a/crates/java-bridge/src/node/extensions/class_ext.rs
+++ b/crates/java-bridge/src/node/extensions/class_ext.rs
@@ -18,7 +18,7 @@ fn argument_matches(
 }
 
 fn arguments_match(
-    parameter_types: &Vec<JavaType>,
+    parameter_types: &[JavaType],
     ctx: &CallContext,
     allow_objects: bool,
 ) -> napi::Result<bool> {
@@ -26,8 +26,8 @@ fn arguments_match(
         return Ok(false);
     }
 
-    for i in 0..ctx.length {
-        if !argument_matches(&parameter_types[i], ctx.get(i)?, ctx.env, allow_objects)? {
+    for (i, param) in parameter_types.iter().enumerate() {
+        if !argument_matches(param, ctx.get(i)?, ctx.env, allow_objects)? {
             return Ok(false);
         }
     }

--- a/crates/java-bridge/src/node/extensions/java_call_result_ext.rs
+++ b/crates/java-bridge/src/node/extensions/java_call_result_ext.rs
@@ -1,6 +1,6 @@
 use crate::node::class_cache::ClassCache;
 use crate::node::java_class_instance::JavaClassInstance;
-use crate::node::util::util::ResultType;
+use crate::node::util::helpers::ResultType;
 use app_state::{stateful, AppStateTrait, MutAppState};
 use java_rs::java_call_result::JavaCallResult;
 use java_rs::java_env::JavaEnv;
@@ -128,7 +128,7 @@ impl ToNapiValue for JavaCallResult {
         objects: bool,
         cache: MutAppState<ClassCache>,
     ) -> ResultType<JsUnknown> {
-        let obj = LocalJavaObject::from(object, &j_env);
+        let obj = LocalJavaObject::from(object, j_env);
         let res = match signature.type_enum() {
             Type::LangInteger => env.create_int32(j_env.object_to_int(&obj)?)?.into_unknown(),
             Type::LangLong => env
@@ -196,7 +196,7 @@ impl ToNapiValue for JavaCallResult {
         env: &Env,
         signature: Arc<Mutex<JavaType>>,
     ) -> ResultType<JsUnknown> {
-        let obj = LocalJavaObject::from(object, &j_env);
+        let obj = LocalJavaObject::from(object, j_env);
         let arr = JavaArray::from(obj);
 
         let mut res = env.create_array(arr.len()? as u32)?;
@@ -205,44 +205,44 @@ impl ToNapiValue for JavaCallResult {
         match sig.type_enum() {
             Type::Integer => {
                 let data = JavaIntArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i])?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item)?;
                 }
             }
             Type::Long => {
                 let data = JavaLongArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i])?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item)?;
                 }
             }
             Type::Short => {
                 let data = JavaShortArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i])?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item)?;
                 }
             }
             Type::Double => {
                 let data = JavaDoubleArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i])?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item)?;
                 }
             }
             Type::Float => {
                 let data = JavaFloatArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i] as f64)?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item as f64)?;
                 }
             }
             Type::Boolean => {
                 let data = JavaBooleanArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, data[i] != 0)?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, *item != 0)?;
                 }
             }
             Type::Character => {
                 let data = JavaCharArray::from(arr).get_data()?;
-                for i in 0..data.len() {
-                    res.set(i as u32, env.create_string_utf16(&[data[i]]))?;
+                for (i, item) in data.iter().enumerate() {
+                    res.set(i as u32, env.create_string_utf16(&[*item]))?;
                 }
             }
             Type::Byte => {

--- a/crates/java-bridge/src/node/extensions/java_type_ext.rs
+++ b/crates/java-bridge/src/node/extensions/java_type_ext.rs
@@ -89,11 +89,13 @@ impl JsTypeEq for JavaType {
                     }
 
                     let obj = env.unwrap::<GlobalJavaObject>(&proxy.coerce_to_object()?)?;
-                    let j_env = obj.get_vm().attach_thread().map_napi_err()?;
-                    let other_class = obj.get_class(&j_env).map_napi_err()?;
+                    let j_env = obj.get_vm().attach_thread().map_napi_err(Some(*env))?;
+                    let other_class = obj.get_class(&j_env).map_napi_err(Some(*env))?;
 
-                    let self_class = self.as_class(&j_env).map_napi_err()?;
-                    self_class.is_assignable_from(&other_class).map_napi_err()?
+                    let self_class = self.as_class(&j_env).map_napi_err(Some(*env))?;
+                    self_class
+                        .is_assignable_from(&other_class)
+                        .map_napi_err(Some(*env))?
                 } else if !self.is_array()
                     && !other.is_promise()?
                     && !other.is_date()?
@@ -112,10 +114,12 @@ impl JsTypeEq for JavaType {
                     }
 
                     let class = class.unwrap();
-                    let j_env = class.vm.attach_thread().map_napi_err()?;
-                    let self_class = self.as_class(&j_env).map_napi_err()?;
+                    let j_env = class.vm.attach_thread().map_napi_err(Some(*env))?;
+                    let self_class = self.as_class(&j_env).map_napi_err(Some(*env))?;
                     let other_class = JavaClass::from_global(&class.class, &j_env);
-                    self_class.is_assignable_from(&other_class).map_napi_err()?
+                    self_class
+                        .is_assignable_from(&other_class)
+                        .map_napi_err(Some(*env))?
                 } else {
                     false
                 }

--- a/crates/java-bridge/src/node/helpers/arg_convert.rs
+++ b/crates/java-bridge/src/node/helpers/arg_convert.rs
@@ -19,7 +19,7 @@ pub fn call_context_to_java_args<'a>(
             i,
             signature
                 .convert_to_java_value(env, ctx.env, js_value)
-                .map_napi_err()?,
+                .map_napi_err(Some(*ctx.env))?,
         );
     }
 

--- a/crates/java-bridge/src/node/helpers/arg_convert.rs
+++ b/crates/java-bridge/src/node/helpers/arg_convert.rs
@@ -8,7 +8,7 @@ use napi::{CallContext, JsUnknown};
 
 pub fn call_context_to_java_args<'a>(
     ctx: &'a CallContext,
-    signatures: &'a Vec<JavaType>,
+    signatures: &'a [JavaType],
     env: &'a JavaEnv<'a>,
 ) -> napi::Result<Vec<JavaCallResult>> {
     let mut res: Vec<JavaCallResult> = vec![];
@@ -26,7 +26,7 @@ pub fn call_context_to_java_args<'a>(
     Ok(res)
 }
 
-pub fn call_results_to_args(args: &Vec<JavaCallResult>) -> Vec<JavaArg> {
+pub fn call_results_to_args(args: &[JavaCallResult]) -> Vec<JavaArg> {
     args.iter()
         .map(|arg| arg.as_arg())
         .collect::<Vec<JavaArg>>()

--- a/crates/java-bridge/src/node/helpers/napi_error.rs
+++ b/crates/java-bridge/src/node/helpers/napi_error.rs
@@ -1,3 +1,11 @@
+use crate::debug;
+use crate::node::class_cache::ClassCache;
+use crate::node::java_class_instance::JavaClassInstance;
+use crate::node::util::util::ResultType;
+use app_state::{AppStateTrait, MutAppState};
+use java_rs::java_error::JavaError;
+use java_rs::objects::java_object::JavaObject;
+use napi::{JsError, Property, PropertyAttributes};
 use std::error::Error;
 
 pub struct NapiError(napi::Error);
@@ -46,19 +54,62 @@ impl Into<napi::Error> for NapiError {
 }
 
 pub trait MapToNapiError<T> {
-    fn map_napi_err(self) -> napi::Result<T>;
+    fn map_napi_err(self, env: Option<napi::Env>) -> napi::Result<T>;
 }
 
 impl<T, E> MapToNapiError<T> for Result<T, E>
 where
-    E: ToString,
+    E: Into<Box<dyn Error + Send + Sync>>,
 {
-    fn map_napi_err(self) -> napi::Result<T> {
+    fn map_napi_err(self, env: Option<napi::Env>) -> napi::Result<T> {
         match self {
             Ok(val) => Ok(val),
-            Err(err) => Err(NapiError::from(err.to_string()).into_napi()),
+            Err(err) => {
+                let error_box = err.into();
+                let napi_error = NapiError::from(error_box.to_string()).into_napi();
+
+                match convert_error(env, &error_box, &napi_error) {
+                    Ok(napi_error) => Err(napi_error),
+                    Err(_err) => {
+                        debug!("Failed to convert error: {_err}");
+                        Err(napi_error)
+                    }
+                }
+            }
         }
     }
+}
+
+fn convert_error(
+    env: Option<napi::Env>,
+    error: &Box<dyn Error + Send + Sync>,
+    napi_error: &napi::Error,
+) -> ResultType<napi::Error> {
+    let env = env.ok_or("Missing n-api environment")?;
+    let java_err = error
+        .downcast_ref::<JavaError>()
+        .ok_or("Error is not of type 'JavaError'")?;
+    let throwable = java_err.get_throwable().ok_or("Missing java throwable")?;
+    let mut error_obj = JsError::from(napi_error.clone())
+        .into_unknown(env)
+        .coerce_to_object()?;
+
+    let vm = throwable.get_vm();
+    let java_env = vm.attach_thread()?;
+    let throwable_name = java_env.get_class_name(JavaObject::from(&throwable))?;
+
+    let proxy = MutAppState::<ClassCache>::get_or_insert_default()
+        .try_lock()
+        .map_err(|_| "Failed to lock class cache")?
+        .get_class_proxy(&vm, throwable_name, None)?;
+    let converted_throwable = JavaClassInstance::from_existing(proxy, &env, throwable)?;
+    error_obj.define_properties(&[Property::new("cause")?
+        .with_value(&converted_throwable)
+        .with_property_attributes(
+            PropertyAttributes::Enumerable | PropertyAttributes::Configurable,
+        )])?;
+
+    Ok(napi::Error::from(error_obj.into_unknown()))
 }
 
 pub trait StrIntoNapiError {

--- a/crates/java-bridge/src/node/interface_proxy/function_caller.rs
+++ b/crates/java-bridge/src/node/interface_proxy/function_caller.rs
@@ -1,6 +1,7 @@
 use crate::node::helpers::napi_error::MapToNapiError;
 use java_rs::objects::java_object::JavaObject;
 use java_rs::objects::object::GlobalJavaObject;
+use napi::Env;
 
 pub struct FunctionCaller {
     instance: Option<GlobalJavaObject>,
@@ -21,18 +22,18 @@ impl FunctionCaller {
         self.instance.is_none()
     }
 
-    pub fn destroy(&mut self) -> napi::Result<()> {
+    pub fn destroy(&mut self, env: Option<Env>) -> napi::Result<()> {
         if let Some(instance) = self.instance.as_ref() {
-            let env = instance.get_vm().attach_thread().map_napi_err()?;
-            let java_class = env
+            let java_env = instance.get_vm().attach_thread().map_napi_err(env)?;
+            let java_class = java_env
                 .get_object_class(JavaObject::from(instance))
-                .map_napi_err()?;
+                .map_napi_err(None)?;
             let destruct = java_class
                 .get_void_method("destruct", "()V")
-                .map_napi_err()?;
+                .map_napi_err(env)?;
             destruct
                 .call(JavaObject::from(instance), &[])
-                .map_napi_err()?;
+                .map_napi_err(env)?;
 
             self.instance.take();
         }
@@ -51,7 +52,7 @@ impl FunctionCaller {
 
 impl Drop for FunctionCaller {
     fn drop(&mut self) {
-        if let Err(e) = self.destroy() {
+        if let Err(e) = self.destroy(None) {
             eprintln!("Error while dropping FunctionCaller: {}", e);
         }
     }

--- a/crates/java-bridge/src/node/interface_proxy/function_caller.rs
+++ b/crates/java-bridge/src/node/interface_proxy/function_caller.rs
@@ -42,11 +42,7 @@ impl FunctionCaller {
     }
 
     pub fn move_to(&mut self) -> Option<FunctionCaller> {
-        if let Some(obj) = self.instance.take() {
-            Some(FunctionCaller::new(obj))
-        } else {
-            None
-        }
+        self.instance.take().map(FunctionCaller::new)
     }
 }
 

--- a/crates/java-bridge/src/node/interface_proxy/interface_call.rs
+++ b/crates/java-bridge/src/node/interface_proxy/interface_call.rs
@@ -1,7 +1,7 @@
 use crate::node::interface_proxy::types::JsCallResult;
 use futures::channel::oneshot::Sender;
 use java_rs::java_call_result::JavaCallResult;
-use java_rs::util::util::ResultType;
+use java_rs::util::helpers::ResultType;
 use std::sync::Mutex;
 
 pub struct InterfaceCall {

--- a/crates/java-bridge/src/node/interface_proxy/interface_proxy_options.rs
+++ b/crates/java-bridge/src/node/interface_proxy/interface_proxy_options.rs
@@ -1,15 +1,8 @@
 /// Options for the interface proxies
 #[napi(object)]
+#[derive(Default)]
 pub struct InterfaceProxyOptions {
     /// If true, the proxy will be kept as a daemon
     /// proxy after the interface has been destroyed
     pub keep_as_daemon: Option<bool>,
-}
-
-impl Default for InterfaceProxyOptions {
-    fn default() -> Self {
-        Self {
-            keep_as_daemon: None,
-        }
-    }
 }

--- a/crates/java-bridge/src/node/interface_proxy/java_interface_proxy.rs
+++ b/crates/java-bridge/src/node/interface_proxy/java_interface_proxy.rs
@@ -21,7 +21,7 @@ use java_rs::objects::java_object::JavaObject;
 use java_rs::objects::object::{GlobalJavaObject, LocalJavaObject};
 use java_rs::objects::string::JavaString;
 use java_rs::objects::value::JavaLong;
-use java_rs::util::util::ResultType;
+use java_rs::util::helpers::ResultType;
 use java_rs::{function, sys};
 use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
 use napi::{CallContext, Env, JsFunction, JsObject, JsString, JsUnknown};
@@ -86,7 +86,7 @@ unsafe fn call_node_function(
         .ok_or(format!("No method with the name '{}' exists", name))?;
 
     let mut converted_args: Vec<JavaCallResult> = Vec::new();
-    if args != ptr::null_mut() {
+    if !args.is_null() {
         let args = JavaObjectArray::from_raw(args, &env, None);
         for i in 0..args.len()? {
             let arg = args.get(i)?;
@@ -135,8 +135,7 @@ fn js_callback(
                 .and_then(|s| s.as_str().ok())
                 .map(|stack| {
                     stack
-                        .split("\n")
-                        .into_iter()
+                        .split('\n')
                         .map(|s| s.to_string())
                         .collect::<Vec<String>>()
                 })
@@ -154,7 +153,7 @@ fn js_callback(
     } else {
         let env = vm.attach_thread()?;
         let result = ctx.get::<JsUnknown>(1)?;
-        let converted = JavaType::object().convert_to_java_object(&env, &ctx.env, result)?;
+        let converted = JavaType::object().convert_to_java_object(&env, ctx.env, result)?;
 
         Ok(Ok(if let Some(converted) = converted {
             Some(converted.into_global()?)

--- a/crates/java-bridge/src/node/interface_proxy/js_error.rs
+++ b/crates/java-bridge/src/node/interface_proxy/js_error.rs
@@ -1,4 +1,4 @@
-use crate::node::util::util::ResultType;
+use crate::node::util::helpers::ResultType;
 use java_rs::function;
 use java_rs::java_env::JavaEnv;
 use java_rs::objects::args::AsJavaArg;
@@ -27,7 +27,7 @@ impl JsError {
     }
 
     pub fn throw(&self, env: &JavaEnv) -> ResultType<()> {
-        let utils = JavaClass::by_name("io/github/markusjx/bridge/Util", &env)?;
+        let utils = JavaClass::by_name("io/github/markusjx/bridge/Util", env)?;
         let exception_from_js_error = utils.get_static_object_method(
             "exceptionFromJsError",
             "(Ljava/lang/String;[Ljava/lang/String;)Ljava/lang/Exception;",
@@ -36,7 +36,7 @@ impl JsError {
         let mut stack = self.stack.clone();
         Self::push_stack(&mut stack, function!(), file!(), line!());
 
-        let string_class = JavaClass::by_name("java/lang/String", &env)?;
+        let string_class = JavaClass::by_name("java/lang/String", env)?;
         let mut java_stack = JavaObjectArray::new(&string_class, stack.len() as _)?;
 
         for i in 0..stack.len() {
@@ -44,14 +44,14 @@ impl JsError {
                 i as _,
                 Some(JavaObject::from(JavaString::from_string(
                     stack.get(i).unwrap().clone(),
-                    &env,
+                    env,
                 )?)),
             )?;
         }
 
         let exception = exception_from_js_error
             .call(&[
-                JavaString::from_string(self.message.clone(), &env)?.as_arg(),
+                JavaString::from_string(self.message.clone(), env)?.as_arg(),
                 java_stack.as_arg(),
             ])?
             .ok_or(

--- a/crates/java-bridge/src/node/interface_proxy/proxies.rs
+++ b/crates/java-bridge/src/node/interface_proxy/proxies.rs
@@ -1,6 +1,6 @@
 use crate::node::interface_proxy::function_caller::FunctionCaller;
 use crate::node::interface_proxy::types::{MethodMap, MethodsType, ProxiesType};
-use crate::node::util::util::ResultType;
+use crate::node::util::helpers::ResultType;
 use lazy_static::lazy_static;
 use napi::Env;
 use rand::Rng;
@@ -51,7 +51,7 @@ pub(in crate::node::interface_proxy) fn find_methods_by_id(
     }
 }
 
-pub(in crate::node::interface_proxy) fn remove_proxy<'a>(
+pub(in crate::node::interface_proxy) fn remove_proxy(
     id: usize,
     keep_as_daemon: bool,
     proxies: &mut MutexGuard<ProxiesType>,
@@ -73,6 +73,7 @@ pub fn interface_proxy_exists() -> bool {
 
 /// Clears the list of daemon proxies.
 #[napi]
+#[allow(unused)]
 pub fn clear_daemon_proxies(env: Env) -> napi::Result<()> {
     let mut proxies = DAEMON_PROXIES.lock().unwrap();
     for (_, (methods, function_caller)) in proxies.iter_mut() {

--- a/crates/java-bridge/src/node/interface_proxy/proxies.rs
+++ b/crates/java-bridge/src/node/interface_proxy/proxies.rs
@@ -2,6 +2,7 @@ use crate::node::interface_proxy::function_caller::FunctionCaller;
 use crate::node::interface_proxy::types::{MethodMap, MethodsType, ProxiesType};
 use crate::node::util::util::ResultType;
 use lazy_static::lazy_static;
+use napi::Env;
 use rand::Rng;
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard};
@@ -72,10 +73,10 @@ pub fn interface_proxy_exists() -> bool {
 
 /// Clears the list of daemon proxies.
 #[napi]
-pub fn clear_daemon_proxies() -> napi::Result<()> {
+pub fn clear_daemon_proxies(env: Env) -> napi::Result<()> {
     let mut proxies = DAEMON_PROXIES.lock().unwrap();
     for (_, (methods, function_caller)) in proxies.iter_mut() {
-        function_caller.destroy()?;
+        function_caller.destroy(Some(env))?;
         methods.lock().unwrap().clear();
     }
 

--- a/crates/java-bridge/src/node/java.rs
+++ b/crates/java-bridge/src/node/java.rs
@@ -8,7 +8,7 @@ use crate::node::java_class_instance::{JavaClassInstance, CLASS_PROXY_PROPERTY, 
 use crate::node::java_class_proxy::JavaClassProxy;
 use crate::node::java_options::JavaOptions;
 use crate::node::stdout_redirect::StdoutRedirect;
-use crate::node::util::util::{list_files, parse_array_or_string, parse_classpath_args};
+use crate::node::util::helpers::{list_files, parse_array_or_string, parse_classpath_args};
 use app_state::{stateful, AppStateTrait, MutAppState, MutAppStateLock};
 use futures::future;
 use java_rs::java_env::JavaEnv;
@@ -49,7 +49,7 @@ impl Java {
         env: Env,
     ) -> napi::Result<Self> {
         let ver = version.unwrap_or("1.8".to_string());
-        let mut args = opts.unwrap_or(vec![]);
+        let mut args = opts.unwrap_or_default();
         let mut loaded_jars = vec![];
 
         debug!("Loading JVM version {}", ver);
@@ -214,7 +214,7 @@ impl Java {
             env,
             classname,
             methods,
-            options.unwrap_or(InterfaceProxyOptions::default()),
+            options.unwrap_or_default(),
         )
         .map_napi_err(Some(env))
     }
@@ -315,6 +315,7 @@ impl Java {
 /// @since 2.4.0
 #[stateful(init(cache))]
 #[napi]
+#[allow(unused)]
 pub fn clear_class_proxies(mut cache: MutAppStateLock<ClassCache>) {
     cache.clear();
 }

--- a/crates/java-bridge/src/node/java.rs
+++ b/crates/java-bridge/src/node/java.rs
@@ -46,6 +46,7 @@ impl Java {
         java_options: Option<JavaOptions>,
         java_lib_path: String,
         native_lib_path: String,
+        env: Env,
     ) -> napi::Result<Self> {
         let ver = version.unwrap_or("1.8".to_string());
         let mut args = opts.unwrap_or(vec![]);
@@ -68,22 +69,26 @@ impl Java {
         }
 
         debug!("Parsed classpath args: {:?}", args);
-        let root_vm = JavaVM::new(&ver, lib_path, &args).map_napi_err()?;
+        let root_vm = JavaVM::new(&ver, lib_path, &args).map_napi_err(Some(env))?;
 
-        let env = root_vm.attach_thread().map_napi_err()?;
-        env.append_class_path(vec![java_lib_path]).map_napi_err()?;
-        let native_library_class =
-            JavaClass::by_java_name("io.github.markusjx.bridge.NativeLibrary".to_string(), &env)
-                .map_napi_err()?;
+        let java_env = root_vm.attach_thread().map_napi_err(Some(env))?;
+        java_env
+            .append_class_path(vec![java_lib_path])
+            .map_napi_err(Some(env))?;
+        let native_library_class = JavaClass::by_java_name(
+            "io.github.markusjx.bridge.NativeLibrary".to_string(),
+            &java_env,
+        )
+        .map_napi_err(Some(env))?;
 
         let load_library = native_library_class
             .get_static_void_method("loadLibrary", "(Ljava/lang/String;)V")
-            .map_napi_err()?;
+            .map_napi_err(Some(env))?;
         load_library
-            .call(&[JavaString::from_string(native_lib_path, &env)
-                .map_napi_err()?
+            .call(&[JavaString::from_string(native_lib_path, &java_env)
+                .map_napi_err(Some(env))?
                 .as_arg()])
-            .map_napi_err()?;
+            .map_napi_err(Some(env))?;
 
         Ok(Self {
             root_vm,
@@ -105,7 +110,7 @@ impl Java {
         let proxy = MutAppState::<ClassCache>::get_or_insert_default()
             .get_mut()
             .get_class_proxy(&self.root_vm, class_name, config)
-            .map_napi_err()?;
+            .map_napi_err(Some(env))?;
         JavaClassInstance::create_class_instance(&env, proxy)
     }
 
@@ -124,7 +129,7 @@ impl Java {
                 MutAppState::<ClassCache>::get_or_insert_default()
                     .get_mut()
                     .get_class_proxy(&self.root_vm, class_name, config)
-                    .map_napi_err()
+                    .map_napi_err(None)
             }),
             |&mut env, proxy| JavaClassInstance::create_class_instance(&env, proxy),
         )
@@ -140,8 +145,8 @@ impl Java {
     /// Get the actual JVM version.
     /// This may not match the wanted JVM version.
     #[napi(getter)]
-    pub fn version(&self) -> napi::Result<String> {
-        self.root_vm.get_version().map_napi_err()
+    pub fn version(&self, env: Env) -> napi::Result<String> {
+        self.root_vm.get_version().map_napi_err(Some(env))
     }
 
     /// Get the loaded jars.
@@ -156,14 +161,17 @@ impl Java {
         &mut self,
         classpath: JsUnknown,
         ignore_unreadable: Option<bool>,
+        env: Env,
     ) -> napi::Result<()> {
         let mut paths = list_files(
             parse_array_or_string(classpath)?,
             ignore_unreadable.unwrap_or(false),
         )?;
 
-        let env = self.root_vm.attach_thread().map_napi_err()?;
-        env.append_class_path(paths.clone()).map_napi_err()?;
+        let java_env = self.root_vm.attach_thread().map_napi_err(Some(env))?;
+        java_env
+            .append_class_path(paths.clone())
+            .map_napi_err(Some(env))?;
         self.loaded_jars.append(&mut paths);
 
         Ok(())
@@ -179,7 +187,7 @@ impl Java {
         #[napi(ts_arg_type = "((err: Error | null, data?: string) => void) | undefined | null")]
         stderr_callback: Option<JsFunction>,
     ) -> napi::Result<StdoutRedirect> {
-        let j_env = self.root_vm.attach_thread().map_napi_err()?;
+        let j_env = self.root_vm.attach_thread().map_napi_err(Some(env))?;
         StdoutRedirect::new(
             env,
             &j_env,
@@ -187,7 +195,7 @@ impl Java {
             stdout_callback,
             stderr_callback,
         )
-        .map_napi_err()
+        .map_napi_err(Some(env))
     }
 
     #[napi]
@@ -208,7 +216,7 @@ impl Java {
             methods,
             options.unwrap_or(InterfaceProxyOptions::default()),
         )
-        .map_napi_err()
+        .map_napi_err(Some(env))
     }
 
     /// Check if `this` is instance of `other`
@@ -219,7 +227,7 @@ impl Java {
         this_obj: JsObject,
         #[napi(ts_arg_type = "string | object")] other: JsUnknown,
     ) -> napi::Result<bool> {
-        let env = self.root_vm.attach_thread().map_napi_err()?;
+        let env = self.root_vm.attach_thread().map_napi_err(Some(node_env))?;
         Self::_is_instance_of(env, &node_env, this_obj, other)
     }
 
@@ -228,9 +236,13 @@ impl Java {
         let proxy = MutAppState::<ClassCache>::get_or_insert_default()
             .get_mut()
             .get_class_proxy(&self.root_vm, "java.net.URLClassLoader".into(), None)
-            .map_napi_err()?;
-        let j_env = self.root_vm.attach_thread().map_napi_err()?;
-        JavaClassInstance::from_existing(proxy, &env, j_env.get_class_loader().map_napi_err()?)
+            .map_napi_err(Some(env))?;
+        let j_env = self.root_vm.attach_thread().map_napi_err(Some(env))?;
+        JavaClassInstance::from_existing(
+            proxy,
+            &env,
+            j_env.get_class_loader().map_napi_err(Some(env))?,
+        )
     }
 
     #[napi(setter)]
@@ -239,12 +251,14 @@ impl Java {
         env: Env,
         #[napi(ts_arg_type = "object")] class_loader: JsUnknown,
     ) -> napi::Result<()> {
-        let j_env = self.root_vm.attach_thread().map_napi_err()?;
+        let j_env = self.root_vm.attach_thread().map_napi_err(Some(env))?;
         let obj = class_loader.coerce_to_object()?;
         let instance =
             env.unwrap::<GlobalJavaObject>(&obj.get_named_property::<JsObject>(OBJECT_PROPERTY)?)?;
 
-        j_env.replace_class_loader(instance.clone()).map_napi_err()
+        j_env
+            .replace_class_loader(instance.clone())
+            .map_napi_err(Some(env))
     }
 
     #[napi]
@@ -266,7 +280,7 @@ impl Java {
     ) -> napi::Result<bool> {
         let other = if other.get_type()? == ValueType::String {
             env.find_global_class_by_java_name(other.coerce_to_string()?.into_utf16()?.as_str()?)
-                .map_napi_err()?
+                .map_napi_err(Some(*node_env))?
         } else if other.get_type()? == ValueType::Function || other.get_type()? == ValueType::Object
         {
             let err_fn = |_| "'other' is not a java object".into_napi_err();
@@ -290,7 +304,7 @@ impl Java {
             .map_err(err_fn)?;
 
         env.instance_of(JavaObject::from(this.clone()), other)
-            .map_napi_err()
+            .map_napi_err(Some(*node_env))
     }
 }
 

--- a/crates/java-bridge/src/node/java_class_instance.rs
+++ b/crates/java-bridge/src/node/java_class_instance.rs
@@ -75,7 +75,8 @@ impl JavaClassInstance {
         }
 
         constructor.define_properties(
-            (&proxy.static_fields)
+            proxy
+                .static_fields
                 .iter()
                 .map(|(name, field)| {
                     let name = name.clone();
@@ -208,8 +209,9 @@ impl JavaClassInstance {
         }
 
         this.define_properties(
-            (&proxy.fields)
-                .into_iter()
+            proxy
+                .fields
+                .iter()
                 .map(|(name, field)| -> napi::Result<Property> {
                     let name = name.clone();
                     let name_cpy = name.clone();
@@ -386,7 +388,7 @@ impl JavaClassInstance {
             let args_ref = call_results_to_args(&args);
 
             method
-                .call(&obj, args_ref.as_slice())
+                .call(obj, args_ref.as_slice())
                 .map_napi_err(Some(*ctx.env))?
         };
 
@@ -437,14 +439,14 @@ impl JavaClassInstance {
                         .get("toString")
                         .ok_or(napi::Error::from_reason("Method toString not found"))?
                         .iter()
-                        .find(|m| m.parameter_types().len() == 0)
+                        .find(|m| m.parameter_types().is_empty())
                         .ok_or(napi::Error::from_reason("Method toString not found"))?;
 
                     let obj = Self::get_object(&ctx)?;
                     let env = proxy.vm.attach_thread().map_napi_err(Some(*ctx.env))?;
 
-                    let res = method.call(&obj, &[]).map_napi_err(Some(*ctx.env))?;
-                    res.to_napi_value(&env, &ctx.env)
+                    let res = method.call(obj, &[]).map_napi_err(Some(*ctx.env))?;
+                    res.to_napi_value(&env, ctx.env)
                         .map_napi_err(Some(*ctx.env))
                 },
             )?,
@@ -521,7 +523,7 @@ fn get_class_field(ctx: CallContext) -> napi::Result<JsObject> {
         signature: JavaType::new("java.lang.Class".to_string(), false),
     };
 
-    res.to_napi_value(&j_env, &ctx.env)
+    res.to_napi_value(&j_env, ctx.env)
         .map_napi_err(Some(*ctx.env))?
         .coerce_to_object()
 }

--- a/crates/java-bridge/src/node/java_class_proxy.rs
+++ b/crates/java-bridge/src/node/java_class_proxy.rs
@@ -122,6 +122,10 @@ impl JavaClassProxy {
             .get(name)
             .ok_or(format!("No static field found with name '{}'", name).into())
     }
+
+    pub fn async_java_exception_objects(&self) -> bool {
+        self.config.async_java_exception_objects.unwrap_or_default()
+    }
 }
 
 unsafe impl Send for JavaClassProxy {}

--- a/crates/java-bridge/src/node/java_class_proxy.rs
+++ b/crates/java-bridge/src/node/java_class_proxy.rs
@@ -5,7 +5,7 @@ use crate::node::config::Config;
 use crate::node::extensions::class_ext::ArgumentMatch;
 use java_rs::java_vm::JavaVM;
 use java_rs::objects::class::GlobalJavaClass;
-use java_rs::util::util::ResultType;
+use java_rs::util::helpers::ResultType;
 use napi::CallContext;
 use std::collections::HashMap;
 
@@ -62,8 +62,8 @@ impl JavaClassProxy {
             })
             .collect::<napi::Result<Vec<Option<&ClassMethod>>>>()?
             .iter()
-            .filter(|m| m.is_some())
-            .map(|m| m.unwrap())
+            .flatten()
+            .copied()
             .next()
             .ok_or(
                 format!(
@@ -95,8 +95,8 @@ impl JavaClassProxy {
             })
             .collect::<napi::Result<Vec<Option<&ClassConstructor>>>>()?
             .iter()
-            .filter(|c| c.is_some())
-            .map(|c| c.unwrap())
+            .flatten()
+            .copied()
             .next()
             .ok_or(
                 format!(

--- a/crates/java-bridge/src/node/java_config.rs
+++ b/crates/java-bridge/src/node/java_config.rs
@@ -22,6 +22,7 @@ impl JavaConfig {
     /// Do not instantiate this class.
     /// Use the {@link default.config} instance instead.
     #[napi(constructor)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self
     }

--- a/crates/java-bridge/src/node/java_config.rs
+++ b/crates/java-bridge/src/node/java_config.rs
@@ -167,6 +167,26 @@ impl JavaConfig {
         Config::get().async_suffix.clone()
     }
 
+    /// Get whether to return Java exceptions as objects in async methods.
+    ///
+    /// @since 2.6.0
+    #[napi(getter)]
+    pub fn get_async_java_exception_objects(&self) -> Option<bool> {
+        Config::get().async_java_exception_objects
+    }
+
+    /// If true, any Java exception will be returned in the `cause`
+    /// field of the thrown `JavaError` even in async methods.
+    /// Enabling this will cause the stack trace of the
+    /// JavaScript error to be lost.
+    /// If not specified, the value from the global configuration will be used.
+    ///
+    /// @since 2.6.0
+    #[napi(setter, ts_args_type = "value: boolean | undefined | null")]
+    pub fn set_async_java_exception_objects(&self, value: Option<bool>) {
+        Config::get().async_java_exception_objects = value;
+    }
+
     /// Override the whole config.
     /// If you want to change only a single field, use the static setters instead.
     ///

--- a/crates/java-bridge/src/node/java_options.rs
+++ b/crates/java-bridge/src/node/java_options.rs
@@ -1,6 +1,7 @@
 /// Options for the Java VM.
 /// Not the same as vm arguments.
 #[napi(object)]
+#[derive(Default)]
 pub struct JavaOptions {
     /// Additional items to add to the class path. This does allow for wildcard imports
     /// using glob patterns. If a path is unreadable, an error will be thrown.
@@ -8,13 +9,4 @@ pub struct JavaOptions {
     pub classpath: Option<Vec<String>>,
     /// Whether to ignore unreadable class path entries
     pub ignore_unreadable_class_path_entries: Option<bool>,
-}
-
-impl Default for JavaOptions {
-    fn default() -> Self {
-        JavaOptions {
-            classpath: None,
-            ignore_unreadable_class_path_entries: None,
-        }
-    }
 }

--- a/crates/java-bridge/src/node/stdout_redirect.rs
+++ b/crates/java-bridge/src/node/stdout_redirect.rs
@@ -8,7 +8,7 @@ use java_rs::objects::object::GlobalJavaObject;
 use java_rs::objects::string::JavaString;
 use java_rs::objects::value::JavaBoolean;
 use java_rs::sys;
-use java_rs::util::util::ResultType;
+use java_rs::util::helpers::ResultType;
 use lazy_static::lazy_static;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi::{Env, JsFunction, Status};
@@ -88,7 +88,7 @@ fn map_callback(
     func: &mut MutexGuard<Option<ThreadsafeFunction<String>>>,
 ) -> napi::Result<()> {
     if let Some(callback) = callback {
-        func.replace(env.create_threadsafe_function(&callback, 0, |ctx| {
+        func.replace(env.create_threadsafe_function(callback, 0, |ctx| {
             Ok(vec![ctx.env.create_string_from_std(ctx.value)?])
         })?);
     } else {
@@ -235,12 +235,12 @@ fn set_stdout_callbacks(
 
     let class = JavaClass::by_java_name(
         "io.github.markusjx.bridge.StdoutRedirect".to_string(),
-        &j_env,
+        j_env,
     )?;
     let constructor = class.get_constructor("(ZZ)V")?;
 
     let instance = constructor.new_instance(
-        &j_env,
+        j_env,
         &[
             JavaBoolean::new(stdout_set).as_arg(),
             JavaBoolean::new(stderr_set).as_arg(),
@@ -258,7 +258,7 @@ fn reset_stdout_callbacks(env: &JavaEnv, java_class: Option<&GlobalJavaObject>) 
 
     if let Some(java_class) = java_class {
         let class =
-            JavaClass::by_java_name("io.github.markusjx.bridge.StdoutRedirect".to_string(), &env)?;
+            JavaClass::by_java_name("io.github.markusjx.bridge.StdoutRedirect".to_string(), env)?;
         let reset = class.get_void_method("reset", "()V")?;
 
         reset.call(JavaObject::from(java_class), &[])?;

--- a/crates/java-bridge/src/node/util/helpers.rs
+++ b/crates/java-bridge/src/node/util/helpers.rs
@@ -38,7 +38,7 @@ pub(crate) fn list_files(dirs: Vec<String>, ignore_unreadable: bool) -> napi::Re
         .map(|f| glob(f.as_str()).map_napi_err(None))
         .collect::<napi::Result<Vec<_>>>()?
         .into_iter()
-        .flat_map(|f| f)
+        .flatten()
         .map(|f| f.map_napi_err(None))
         .filter_map(|f| match f {
             Ok(f) => Some(
@@ -57,10 +57,10 @@ pub(crate) fn list_files(dirs: Vec<String>, ignore_unreadable: bool) -> napi::Re
         .collect()
 }
 
-pub fn parse_classpath_args(cp: &Vec<String>, args: &mut Vec<String>) -> String {
-    let mut cp = cp.clone();
+pub fn parse_classpath_args(cp: &[String], args: &mut Vec<String>) -> String {
+    let mut cp = cp.to_vec();
     if let Some(other) = args
-        .into_iter()
+        .iter_mut()
         .position(|e| e.starts_with("-Djava.class.path="))
     {
         let other_cp = args.remove(other).split_at(18).1.to_string();

--- a/crates/java-bridge/src/node/util/mod.rs
+++ b/crates/java-bridge/src/node/util/mod.rs
@@ -1,2 +1,2 @@
+pub mod helpers;
 pub mod traits;
-pub mod util;

--- a/crates/java-bridge/src/node/util/util.rs
+++ b/crates/java-bridge/src/node/util/util.rs
@@ -3,7 +3,7 @@ use glob::glob;
 use napi::{JsString, JsUnknown};
 use std::error::Error;
 
-pub type ResultType<T> = Result<T, Box<dyn Error>>;
+pub type ResultType<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 #[cfg(windows)]
 mod separator {
@@ -35,11 +35,11 @@ pub(crate) fn parse_array_or_string(value: JsUnknown) -> napi::Result<Vec<String
 
 pub(crate) fn list_files(dirs: Vec<String>, ignore_unreadable: bool) -> napi::Result<Vec<String>> {
     dirs.into_iter()
-        .map(|f| glob(f.as_str()).map_napi_err())
+        .map(|f| glob(f.as_str()).map_napi_err(None))
         .collect::<napi::Result<Vec<_>>>()?
         .into_iter()
         .flat_map(|f| f)
-        .map(|f| f.map_napi_err())
+        .map(|f| f.map_napi_err(None))
         .filter_map(|f| match f {
             Ok(f) => Some(
                 f.to_str()

--- a/crates/java-bridge/src/tests/common.rs
+++ b/crates/java-bridge/src/tests/common.rs
@@ -2,7 +2,7 @@ use java_rs::java_vm::JavaVM;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref VM: JavaVM = JavaVM::new(&"1.8".to_string(), None, &vec![]).unwrap();
+    static ref VM: JavaVM = JavaVM::new("1.8", None, &[]).unwrap();
 }
 
 pub fn get_vm() -> JavaVM {

--- a/crates/java-bridge/src/tests/config_test.rs
+++ b/crates/java-bridge/src/tests/config_test.rs
@@ -3,6 +3,6 @@ use crate::node::config::Config;
 #[test]
 pub fn test_default() {
     let config = Config::default();
-    assert_eq!(config.run_event_loop_when_interface_proxy_is_active, false);
-    assert_eq!(config.custom_inspect, false);
+    assert!(!config.run_event_loop_when_interface_proxy_is_active);
+    assert!(!config.custom_inspect);
 }

--- a/crates/java-bridge/src/tests/util_tests.rs
+++ b/crates/java-bridge/src/tests/util_tests.rs
@@ -1,4 +1,4 @@
-use crate::node::util::util::parse_classpath_args;
+use crate::node::util::helpers::parse_classpath_args;
 
 #[test]
 fn parse_classpath_args_basic() {

--- a/crates/java-rs/src/java/java_call_result.rs
+++ b/crates/java-rs/src/java/java_call_result.rs
@@ -64,7 +64,7 @@ impl<'a> ToJavaValue<'a> for JavaCallResult {
 }
 
 impl TryFrom<JavaObject<'_>> for JavaCallResult {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_from(value: JavaObject) -> ResultType<Self> {
         Ok(Self::Object {

--- a/crates/java-rs/src/java/java_call_result.rs
+++ b/crates/java-rs/src/java/java_call_result.rs
@@ -6,7 +6,7 @@ use crate::java::objects::value::{
     JavaValue,
 };
 use crate::java::traits::{GetSignature, ToJavaValue};
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::Type;
 use std::error::Error;
 
@@ -33,7 +33,7 @@ unsafe impl Send for JavaCallResult {}
 impl<'a> ToJavaValue<'a> for JavaCallResult {
     fn to_java_value(&'a self) -> JavaValue<'a> {
         match self {
-            JavaCallResult::Void | JavaCallResult::Null => JavaNull::new().into(),
+            JavaCallResult::Void | JavaCallResult::Null => JavaNull.into(),
             JavaCallResult::Boolean(b) => JavaBoolean::new(*b).into(),
             JavaCallResult::Byte(b) => JavaByte::new(*b).into(),
             JavaCallResult::Character(c) => JavaChar::new(*c).into(),

--- a/crates/java-rs/src/java/java_env.rs
+++ b/crates/java-rs/src/java/java_env.rs
@@ -82,6 +82,10 @@ impl<'a> JavaEnv<'a> {
         self.0.get_object_signature(object)
     }
 
+    pub fn get_class_name(&self, object: JavaObject) -> ResultType<String> {
+        self.0.get_class_name(object)
+    }
+
     pub fn is_instance_of(&self, object: JavaObject, classname: &str) -> ResultType<bool> {
         self.0.is_instance_of(object, classname)
     }

--- a/crates/java-rs/src/java/java_env.rs
+++ b/crates/java-rs/src/java/java_env.rs
@@ -5,7 +5,7 @@ use crate::java::objects::class::{GlobalJavaClass, JavaClass};
 use crate::java::objects::java_object::JavaObject;
 use crate::java::objects::object::{GlobalJavaObject, LocalJavaObject};
 use crate::java::traits::{GetRaw, IsInstanceOf};
-use crate::java::util::util::{jni_version_to_string, ResultType};
+use crate::java::util::helpers::{jni_version_to_string, ResultType};
 use crate::java::vm_ptr::JavaVMPtr;
 use crate::objects::args::AsJavaArg;
 use crate::{define_object_to_val_method, sys};
@@ -27,6 +27,10 @@ impl<'a> JavaEnv<'a> {
         Self(JavaEnvWrapper::new(jvm, env))
     }
 
+    /// Get a java env from a raw pointer.
+    ///
+    /// # Safety
+    /// This function is safe as long as the pointer points to a [`sys::JNIEnv`] or is null.
     pub unsafe fn from_raw(env: *mut sys::JNIEnv) -> Self {
         assert_ne!(env, std::ptr::null_mut());
         Self(JavaEnvWrapper::from_raw(env))
@@ -34,7 +38,7 @@ impl<'a> JavaEnv<'a> {
 
     pub fn get_version(&self) -> ResultType<String> {
         let version: i32 = unsafe { self.0.methods.GetVersion.unwrap()(self.0.env) };
-        Ok(jni_version_to_string(version)?)
+        jni_version_to_string(version)
     }
 
     pub fn find_class(&self, class_name: &str) -> ResultType<JavaClass> {
@@ -207,7 +211,7 @@ impl<'a> JavaEnv<'a> {
         )
     }
 
-    pub(in crate::java) fn delete_global_ref(&self, object: sys::jobject) -> () {
+    pub(in crate::java) fn delete_global_ref(&self, object: sys::jobject) {
         unsafe {
             self.0.methods.DeleteGlobalRef.unwrap()(self.0.env, object);
         }

--- a/crates/java-rs/src/java/java_error.rs
+++ b/crates/java-rs/src/java/java_error.rs
@@ -1,8 +1,13 @@
+use crate::objects::object::GlobalJavaObject;
+use std::error::Error;
+use std::fmt::Debug;
+
 #[derive(Debug)]
 pub struct JavaError {
     causes: Vec<String>,
     stack_frames: Vec<String>,
     alt_text: String,
+    throwable: Option<GlobalJavaObject>,
 }
 
 impl JavaError {
@@ -11,7 +16,26 @@ impl JavaError {
             causes,
             stack_frames,
             alt_text,
+            throwable: None,
         }
+    }
+
+    pub fn new_with_throwable(
+        causes: Vec<String>,
+        stack_frames: Vec<String>,
+        alt_text: String,
+        throwable: GlobalJavaObject,
+    ) -> Self {
+        Self {
+            causes,
+            stack_frames,
+            alt_text,
+            throwable: Some(throwable),
+        }
+    }
+
+    pub fn get_throwable(&self) -> Option<GlobalJavaObject> {
+        self.throwable.clone()
     }
 }
 
@@ -42,8 +66,8 @@ impl std::fmt::Display for JavaError {
     }
 }
 
-impl std::error::Error for JavaError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl Error for JavaError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         Some(self)
     }
 }

--- a/crates/java-rs/src/java/java_field.rs
+++ b/crates/java-rs/src/java/java_field.rs
@@ -3,7 +3,7 @@ use crate::java::java_env::JavaEnv;
 use crate::java::java_type::{JavaType, Type};
 use crate::java::objects::class::{GlobalJavaClass, JavaClass};
 use crate::java::objects::java_object::JavaObject;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::traits::GetSignatureRef;
 use crate::{define_field, sys};
 use std::marker::PhantomData;
@@ -186,7 +186,7 @@ impl<'a> JavaObjectField<'a> {
     }
 
     pub fn get(&self, object: &JavaObject<'_>) -> ResultType<Option<JavaObject>> {
-        self.0.class.env().get_object_field(&self, object)
+        self.0.class.env().get_object_field(self, object)
     }
 
     pub fn set(&self, object: &JavaObject<'_>, value: Option<JavaObject>) -> ResultType<()> {
@@ -207,7 +207,7 @@ impl<'a> JavaObjectField<'a> {
             Ok(Self(JavaField::new(
                 field.field.load(Ordering::Relaxed),
                 field.field_type,
-                &class,
+                class,
                 field.is_static,
             )))
         }
@@ -289,7 +289,7 @@ impl<'a> StaticJavaObjectField<'a> {
             Ok(Self(JavaField::new(
                 field.field.load(Ordering::Relaxed),
                 field.field_type,
-                &class,
+                class,
                 field.is_static,
             )))
         }

--- a/crates/java-rs/src/java/java_type.rs
+++ b/crates/java-rs/src/java/java_type.rs
@@ -1,6 +1,6 @@
 use crate::java::java_env::JavaEnv;
 use crate::java::objects::class::JavaClass;
-use crate::java::util::util::{jni_type_to_java_type, ResultType};
+use crate::java::util::helpers::{jni_type_to_java_type, ResultType};
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -36,22 +36,22 @@ pub enum Type {
 
 impl Type {
     pub fn is_object(&self) -> bool {
-        match self {
+        matches!(
+            self,
             Type::Object
-            | Type::Array
-            | Type::LangBoolean
-            | Type::LangInteger
-            | Type::LangByte
-            | Type::LangCharacter
-            | Type::LangShort
-            | Type::LangLong
-            | Type::LangFloat
-            | Type::LangDouble
-            | Type::LangObject
-            | Type::String
-            | Type::CharSequence => true,
-            _ => false,
-        }
+                | Type::Array
+                | Type::LangBoolean
+                | Type::LangInteger
+                | Type::LangByte
+                | Type::LangCharacter
+                | Type::LangShort
+                | Type::LangLong
+                | Type::LangFloat
+                | Type::LangDouble
+                | Type::LangObject
+                | Type::String
+                | Type::CharSequence
+        )
     }
 }
 
@@ -261,12 +261,12 @@ impl JavaType {
     /// assert_eq!(java_type.to_string(), expected.to_string());
     /// ```
     pub fn from_method_return_type(method_signature: &str) -> ResultType<Self> {
-        let signature = method_signature.split(")").last().ok_or(format!(
+        let signature = method_signature.split(')').last().ok_or(format!(
             "Could not get the return type of signature '{}'",
             method_signature
         ))?;
 
-        if signature.len() == 0 || signature.contains('(') || signature.contains(')') {
+        if signature.is_empty() || signature.contains('(') || signature.contains(')') {
             Err(format!(
                 "Could not get the return type of signature '{}'",
                 method_signature
@@ -360,7 +360,7 @@ impl JavaType {
             Type::Long => "J".to_string(),
             Type::Float => "F".to_string(),
             Type::Double => "D".to_string(),
-            _ => format!("L{};", self.signature.replace(".", "/")),
+            _ => format!("L{};", self.signature.replace('.', "/")),
         }
     }
 

--- a/crates/java-rs/src/java/java_vm.rs
+++ b/crates/java-rs/src/java/java_vm.rs
@@ -1,8 +1,8 @@
 use crate::java::java_env::JavaEnv;
 use crate::java::jni_error::JNIError;
-use crate::java::util::util::{jni_error_to_string, parse_jni_version, ResultType};
+use crate::java::util::helpers::{jni_error_to_string, parse_jni_version, ResultType};
 use crate::java::vm_ptr::JavaVMPtr;
-use crate::library::library::{get_jni_create_java_vm, library_loaded, load_library};
+use crate::library::methods::{get_jni_create_java_vm, library_loaded, load_library};
 use crate::sys;
 use std::error::Error;
 use std::ffi::{c_void, CString};
@@ -27,11 +27,7 @@ struct JavaVMOption {
 
 impl JavaVM {
     /// Create a new Java Virtual Machine.
-    pub fn new(
-        version: &String,
-        library_path: Option<String>,
-        args: &Vec<String>,
-    ) -> ResultType<Self> {
+    pub fn new(version: &str, library_path: Option<String>, args: &[String]) -> ResultType<Self> {
         if !library_loaded() {
             let lib_path = match library_path {
                 Some(lib_path) => lib_path,
@@ -66,7 +62,7 @@ impl JavaVM {
         }
 
         let vm_args = sys::JavaVMInitArgs {
-            version: parse_jni_version(version.as_str())? as i32,
+            version: parse_jni_version(version)? as i32,
             options: opts.as_mut_ptr() as _,
             nOptions: opts.len() as _,
             ignoreUnrecognized: 0,
@@ -105,7 +101,7 @@ impl JavaVM {
 
     pub fn get_version(&self) -> ResultType<String> {
         let env = self.attach_thread()?;
-        Ok(env.get_version()?)
+        env.get_version()
     }
 
     fn _attach_thread<'a>(ptr: &Arc<Mutex<JavaVMPtr>>) -> ResultType<JavaEnv<'a>> {

--- a/crates/java-rs/src/java/java_vm.rs
+++ b/crates/java-rs/src/java/java_vm.rs
@@ -41,7 +41,9 @@ impl JavaVM {
                     let path = base.join(java_locator::get_jvm_dyn_lib_file_name());
 
                     path.to_str()
-                        .ok_or(Box::<dyn Error>::from("Could not create the library path"))?
+                        .ok_or(Box::<dyn Error + Send + Sync>::from(
+                            "Could not create the library path",
+                        ))?
                         .to_string()
                 }
             };

--- a/crates/java-rs/src/java/mod.rs
+++ b/crates/java-rs/src/java/mod.rs
@@ -1,7 +1,7 @@
 pub mod java_call_result;
 pub mod java_env;
 mod java_env_wrapper;
-mod java_error;
+pub mod java_error;
 pub mod java_field;
 pub mod java_type;
 pub mod java_vm;

--- a/crates/java-rs/src/java/objects/array.rs
+++ b/crates/java-rs/src/java/objects/array.rs
@@ -5,7 +5,7 @@ use crate::java::objects::java_object::JavaObject;
 use crate::java::objects::object::LocalJavaObject;
 use crate::java::objects::value::JavaValue;
 use crate::java::traits::{GetRaw, ToJavaValue};
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::{JavaType, Type};
 use crate::traits::GetSignature;
 use crate::{define_array, sys};
@@ -19,6 +19,10 @@ impl JavaArray<'_> {
         self.object
             .env()
             .get_array_length(unsafe { self.object.get_raw() })
+    }
+
+    pub fn is_empty(&self) -> ResultType<bool> {
+        self.len().map(|len| len == 0)
     }
 }
 
@@ -73,6 +77,11 @@ impl<'a> JavaObjectArray<'a> {
         Ok(array)
     }
 
+    /// Create a new JavaObjectArray from a raw jobjectArray.
+    ///
+    /// # Safety
+    /// This function is safe as long as the jobjectArray is a valid jobjectArray
+    /// and not already owned by another JavaObjectArray.
     pub unsafe fn from_raw(
         object: sys::jobject,
         env: &'a JavaEnv<'a>,
@@ -89,6 +98,10 @@ impl<'a> JavaObjectArray<'a> {
 
     pub fn len(&self) -> ResultType<i32> {
         self.0.len()
+    }
+
+    pub fn is_empty(&self) -> ResultType<bool> {
+        self.0.is_empty()
     }
 
     pub fn get(&'a self, i: i32) -> ResultType<Option<LocalJavaObject<'a>>> {
@@ -152,15 +165,15 @@ impl<'a> From<JavaArray<'a>> for JavaObjectArray<'a> {
     }
 }
 
-impl<'a> Into<LocalJavaObject<'a>> for JavaObjectArray<'a> {
-    fn into(self) -> LocalJavaObject<'a> {
-        self.0.object
+impl<'a> From<JavaObjectArray<'a>> for LocalJavaObject<'a> {
+    fn from(value: JavaObjectArray<'a>) -> LocalJavaObject<'a> {
+        value.0.object
     }
 }
 
-impl<'a> Into<JavaObject<'a>> for JavaObjectArray<'a> {
-    fn into(self) -> JavaObject<'a> {
-        JavaObject::from(self.0.object)
+impl<'a> From<JavaObjectArray<'a>> for JavaObject<'a> {
+    fn from(value: JavaObjectArray<'a>) -> JavaObject<'a> {
+        JavaObject::from(value.0.object)
     }
 }
 

--- a/crates/java-rs/src/java/objects/class.rs
+++ b/crates/java-rs/src/java/objects/class.rs
@@ -258,7 +258,7 @@ impl GlobalJavaClass {
 }
 
 impl TryFrom<JavaClass<'_>> for GlobalJavaClass {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_from(class: JavaClass) -> ResultType<Self> {
         let global = GlobalJavaObject::try_from(class.object)?;

--- a/crates/java-rs/src/java/objects/class.rs
+++ b/crates/java-rs/src/java/objects/class.rs
@@ -12,7 +12,7 @@ use crate::java::objects::method::{
 };
 use crate::java::objects::object::{GlobalJavaObject, LocalJavaObject};
 use crate::java::traits::GetRaw;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::traits::GetSignature;
 use crate::{assert_non_null, define_get_method_method, sys};
 use std::error::Error;
@@ -120,7 +120,7 @@ impl<'a> JavaClass<'a> {
         resolve_errors: bool,
     ) -> ResultType<JavaObjectMethod<'a>> {
         let method = self.object.env().get_method_id_with_errors(
-            &self,
+            self,
             method_name,
             signature,
             resolve_errors,
@@ -137,7 +137,7 @@ impl<'a> JavaClass<'a> {
         let method = self
             .object
             .env()
-            .get_static_method_id(&self, method_name, signature)?;
+            .get_static_method_id(self, method_name, signature)?;
 
         StaticJavaObjectMethod::new(method)
     }
@@ -150,7 +150,7 @@ impl<'a> JavaClass<'a> {
         let method = self
             .object
             .env()
-            .get_static_method_id(&self, method_name, signature)?;
+            .get_static_method_id(self, method_name, signature)?;
 
         StaticJavaBooleanMethod::new(method)
     }
@@ -167,7 +167,7 @@ impl<'a> JavaClass<'a> {
     ) -> ResultType<JavaField<'a>> {
         self.object
             .env()
-            .get_field_id(&self, name, signature, is_static)
+            .get_field_id(self, name, signature, is_static)
     }
 
     pub fn from_global(object: &'a GlobalJavaClass, env: &'a JavaEnv<'a>) -> Self {

--- a/crates/java-rs/src/java/objects/constructor.rs
+++ b/crates/java-rs/src/java/objects/constructor.rs
@@ -2,7 +2,7 @@ use crate::java::java_env::JavaEnv;
 use crate::java::objects::args::JavaArgs;
 use crate::java::objects::class::{GlobalJavaClass, JavaClass};
 use crate::java::objects::object::LocalJavaObject;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 #[cfg(feature = "type_check")]
 use crate::signature::Signature;
 use crate::{assert_non_null, sys};

--- a/crates/java-rs/src/java/objects/java_object.rs
+++ b/crates/java-rs/src/java/objects/java_object.rs
@@ -4,7 +4,7 @@ use crate::java::objects::object::{GlobalJavaObject, LocalJavaObject};
 use crate::java::objects::string::JavaString;
 use crate::java::objects::value::JavaValue;
 use crate::java::traits::{GetRaw, GetSignature, ToJavaValue};
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::Type;
 use crate::sys;
 use std::error::Error;
@@ -24,10 +24,10 @@ impl<'a> JavaObject<'a> {
         }
     }
 
-    pub fn clone(&'a self) -> Self {
+    pub fn copy_ref(&'a self) -> Self {
         match self {
             Self::LocalRef(local_object) => JavaObject::LocalRef(local_object),
-            Self::Local(local_object) => JavaObject::LocalRef(&local_object),
+            Self::Local(local_object) => JavaObject::LocalRef(local_object),
             Self::Global(global_object) => JavaObject::Global(global_object.clone()),
         }
     }

--- a/crates/java-rs/src/java/objects/java_object.rs
+++ b/crates/java-rs/src/java/objects/java_object.rs
@@ -48,7 +48,7 @@ impl<'a> GetRaw for JavaObject<'a> {
 }
 
 impl TryInto<GlobalJavaObject> for JavaObject<'_> {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_into(self) -> ResultType<GlobalJavaObject> {
         self.into_global()

--- a/crates/java-rs/src/java/objects/method.rs
+++ b/crates/java-rs/src/java/objects/method.rs
@@ -4,7 +4,7 @@ use crate::java::objects::args::JavaArgs;
 use crate::java::objects::class::{GlobalJavaClass, JavaClass};
 use crate::java::objects::java_object::JavaObject;
 use crate::java::objects::object::LocalJavaObject;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 #[cfg(feature = "type_check")]
 use crate::signature::Signature;
 use crate::{define_java_methods, sys};

--- a/crates/java-rs/src/java/objects/object.rs
+++ b/crates/java-rs/src/java/objects/object.rs
@@ -369,7 +369,7 @@ impl<'a> ToJavaValue<'a> for GlobalJavaObject {
 }
 
 impl<'a> TryFrom<LocalJavaObject<'a>> for GlobalJavaObject {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_from(local: LocalJavaObject<'a>) -> Result<GlobalJavaObject, Self::Error> {
         local.env.new_global_object(
@@ -381,7 +381,7 @@ impl<'a> TryFrom<LocalJavaObject<'a>> for GlobalJavaObject {
 }
 
 impl<'a> TryFrom<JavaString<'a>> for GlobalJavaObject {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_from(string: JavaString<'a>) -> Result<GlobalJavaObject, Self::Error> {
         string.0.env.new_global_object(

--- a/crates/java-rs/src/java/objects/object.rs
+++ b/crates/java-rs/src/java/objects/object.rs
@@ -10,7 +10,7 @@ use crate::java::objects::value::{
     JavaBoolean, JavaByte, JavaChar, JavaDouble, JavaFloat, JavaInt, JavaLong, JavaShort, JavaValue,
 };
 use crate::java::traits::{GetRaw, GetSignature, IsInstanceOf, ToJavaValue};
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java::vm_ptr::JavaVMPtr;
 use crate::java_type::Type;
 use crate::objects::java_object::AsJavaObject;
@@ -45,6 +45,13 @@ impl<'a> LocalJavaObject<'a> {
         }
     }
 
+    /// Create a new local java object from a raw pointer.
+    ///
+    /// # Safety
+    /// This function is unsafe as it creates a new local reference from a raw pointer.
+    /// The object will be deleted when the local reference is deleted.
+    /// This assumes the pointer is actually a valid object pointer and not already
+    /// owned by another local reference.
     pub unsafe fn from_raw(
         object: sys::jobject,
         env: &'a JavaEnv<'a>,
@@ -115,7 +122,7 @@ impl<'a> LocalJavaObject<'a> {
     }
 
     pub(in crate::java) fn env(&'a self) -> &'a JavaEnvWrapper<'a> {
-        &self.env
+        self.env
     }
 
     define_object_value_of_method!(
@@ -183,7 +190,7 @@ impl Debug for LocalJavaObject<'_> {
             f,
             "LocalJavaObject(object: {}, signature: {})",
             unsafe { self.get_raw() } as usize,
-            self.get_signature().to_string()
+            self.get_signature()
         )
     }
 }
@@ -303,6 +310,13 @@ impl GlobalJavaObject {
     /// to the JVM as a method return value.
     /// Creates a new local reference to the object
     /// and allows the returned value to be `null`.
+    ///
+    /// # Safety
+    /// This method converts the object to a local reference
+    /// and returns the raw pointer to the local reference.
+    /// The local reference either has to be destroyed manually
+    /// or will be destroyed when the local reference is returned
+    /// to the JVM.
     pub unsafe fn into_return_value(self, env: &JavaEnv) -> sys::jobject {
         env.create_local_ref(self.get_raw())
     }
@@ -320,7 +334,7 @@ impl Debug for GlobalJavaObject {
             f,
             "GlobalJavaObject(object: {}, signature: {})",
             unsafe { self.get_raw() } as usize,
-            self.get_signature().to_string()
+            self.get_signature()
         )
     }
 }

--- a/crates/java-rs/src/java/objects/string.rs
+++ b/crates/java-rs/src/java/objects/string.rs
@@ -4,7 +4,7 @@ use crate::java::java_type::JavaType;
 use crate::java::objects::object::{GlobalJavaObject, LocalJavaObject};
 use crate::java::objects::value::JavaValue;
 use crate::java::traits::{GetRaw, GetSignature, ToJavaValue};
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::Type;
 use crate::objects::java_object::{AsJavaObject, JavaObject};
 use crate::sys;
@@ -49,6 +49,11 @@ impl<'a> JavaString<'a> {
         Self(LocalJavaObject::from(object, env))
     }
 
+    /// Create a new JavaString from a raw jstring.
+    ///
+    /// # Safety
+    /// This function is safe as long as the jstring is a valid jstring
+    /// and not already owned by another JavaString.
     pub unsafe fn from_raw(env: &'a JavaEnv<'a>, string: sys::jstring) -> Self {
         Self(LocalJavaObject::new(
             string,
@@ -77,9 +82,9 @@ impl<'a> ToJavaValue<'a> for JavaString<'a> {
     }
 }
 
-impl<'a> Into<LocalJavaObject<'a>> for JavaString<'a> {
-    fn into(self) -> LocalJavaObject<'a> {
-        self.0
+impl<'a> From<JavaString<'a>> for LocalJavaObject<'a> {
+    fn from(val: JavaString<'a>) -> Self {
+        val.0
     }
 }
 

--- a/crates/java-rs/src/java/objects/string.rs
+++ b/crates/java-rs/src/java/objects/string.rs
@@ -84,7 +84,7 @@ impl<'a> Into<LocalJavaObject<'a>> for JavaString<'a> {
 }
 
 impl<'a> TryFrom<LocalJavaObject<'a>> for JavaString<'a> {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_from(object: LocalJavaObject<'a>) -> ResultType<Self> {
         if object.get_signature().type_enum() != Type::String {
@@ -102,7 +102,7 @@ impl<'a> AsJavaObject<'a> for JavaString<'a> {
 }
 
 impl TryInto<String> for JavaString<'_> {
-    type Error = Box<dyn Error>;
+    type Error = Box<dyn Error + Send + Sync>;
 
     fn try_into(self) -> Result<String, Self::Error> {
         unsafe { self.0.env().get_string_utf_chars(self.0.get_raw()) }

--- a/crates/java-rs/src/java/objects/value.rs
+++ b/crates/java-rs/src/java/objects/value.rs
@@ -22,13 +22,8 @@ impl<'a> JavaValue<'a> {
     }
 }
 
+#[derive(Default)]
 pub struct JavaNull;
-
-impl JavaNull {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 impl<'a> ToJavaValue<'a> for JavaNull {
     fn to_java_value(&'a self) -> JavaValue<'a> {
@@ -40,8 +35,8 @@ impl<'a> ToJavaValue<'a> for JavaNull {
     }
 }
 
-impl<'a> Into<JavaValue<'a>> for JavaNull {
-    fn into(self) -> JavaValue<'a> {
+impl<'a> From<JavaNull> for JavaValue<'a> {
+    fn from(_: JavaNull) -> JavaValue<'a> {
         JavaValue::new(sys::jvalue { l: ptr::null_mut() })
     }
 }

--- a/crates/java-rs/src/java/signature.rs
+++ b/crates/java-rs/src/java/signature.rs
@@ -1,6 +1,6 @@
 use crate::java_type::JavaType;
 use crate::objects::args::JavaArgs;
-use crate::util::util::ResultType;
+use crate::util::helpers::ResultType;
 use regex::Regex;
 use std::fmt::Display;
 

--- a/crates/java-rs/src/java/traits.rs
+++ b/crates/java-rs/src/java/traits.rs
@@ -1,7 +1,7 @@
 use crate::java::java_type::JavaType;
 use crate::java::objects::class::JavaClass;
 use crate::java::objects::value::JavaValue;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::Type;
 use crate::sys;
 
@@ -9,6 +9,9 @@ use crate::sys;
 pub trait GetRaw {
     /// Get the raw jni pointer from a java object.
     /// The pointer returned must not be null.
+    ///
+    /// # Safety
+    /// This function works with raw pointers and is unsafe.
     unsafe fn get_raw(&self) -> sys::jobject;
 }
 

--- a/crates/java-rs/src/java/util/conversion.rs
+++ b/crates/java-rs/src/java/util/conversion.rs
@@ -8,7 +8,7 @@ use crate::java::objects::java_object::JavaObject;
 use crate::java::objects::method::GlobalJavaMethod;
 use crate::java::objects::object::LocalJavaObject;
 use crate::java::objects::string::JavaString;
-use crate::java::util::util::ResultType;
+use crate::java::util::helpers::ResultType;
 use crate::java_type::Type;
 #[cfg(feature = "type_check")]
 use crate::signature::Signature;
@@ -43,7 +43,7 @@ pub fn get_method_name(env: &JavaEnv, method: &LocalJavaObject) -> ResultType<St
             .call(&[])?
             .ok_or("Method.getName() returned null".to_string())?,
     )?;
-    Ok(method_name.try_into()?)
+    method_name.try_into()
 }
 
 pub fn get_method_return_type(env: &JavaEnv, method: &LocalJavaObject) -> ResultType<JavaType> {
@@ -89,7 +89,7 @@ pub fn get_method_parameters(env: &JavaEnv, method: &LocalJavaObject) -> ResultT
 pub fn get_method_from_signature(
     env: &JavaEnv,
     class_name: String,
-    parameters: &Vec<JavaType>,
+    parameters: &[JavaType],
     return_type: &JavaType,
     name: &str,
     is_static: bool,
@@ -140,7 +140,7 @@ pub fn get_method_from_signature(
 pub fn get_constructor_from_signature(
     env: &JavaEnv,
     class_name: String,
-    parameters: &Vec<JavaType>,
+    parameters: &[JavaType],
 ) -> ResultType<GlobalJavaConstructor> {
     let signature = format!(
         "({})V",
@@ -160,7 +160,7 @@ pub fn get_constructor_from_signature(
         constructor,
         global_class,
         #[cfg(feature = "type_check")]
-        Signature::new(JavaType::void(), parameters.clone()),
+        Signature::new(JavaType::void(), parameters.to_vec()),
     ))
 }
 

--- a/crates/java-rs/src/java/util/helpers.rs
+++ b/crates/java-rs/src/java/util/helpers.rs
@@ -47,7 +47,7 @@ pub fn jni_version_to_string(version: i32) -> Result<String, Box<dyn Error + Sen
 pub type ResultType<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 pub fn jni_type_to_java_type(to_convert: &String) -> String {
-    return if to_convert == "Z" || to_convert == "boolean" {
+    if to_convert == "Z" || to_convert == "boolean" {
         "boolean".to_string()
     } else if to_convert == "B" || to_convert == "byte" {
         "byte".to_string()
@@ -65,13 +65,13 @@ pub fn jni_type_to_java_type(to_convert: &String) -> String {
         "double".to_string()
     } else if to_convert == "V" {
         "void".to_string()
-    } else if !to_convert.is_empty() && to_convert.chars().nth(0).unwrap() == '[' {
+    } else if !to_convert.is_empty() && to_convert.starts_with('[') {
         jni_type_to_java_type(&to_convert.clone()[1..].to_string()) + "[]"
-    } else if !to_convert.is_empty() && to_convert.chars().nth(0).unwrap() == 'L' {
+    } else if !to_convert.is_empty() && to_convert.starts_with('L') {
         to_convert.clone()[1..(to_convert.len() - 1)].replace('/', ".")
     } else {
         to_convert.clone().replace('/', ".")
-    };
+    }
 }
 
 pub fn method_is_public(

--- a/crates/java-rs/src/java/util/mod.rs
+++ b/crates/java-rs/src/java/util/mod.rs
@@ -1,3 +1,3 @@
 pub mod conversion;
+pub mod helpers;
 pub mod macros;
-pub mod util;

--- a/crates/java-rs/src/java/util/util.rs
+++ b/crates/java-rs/src/java/util/util.rs
@@ -18,7 +18,7 @@ pub fn jni_error_to_string(error: i32) -> String {
     }
 }
 
-pub fn parse_jni_version(version: &str) -> Result<u32, Box<dyn Error>> {
+pub fn parse_jni_version(version: &str) -> Result<u32, Box<dyn Error + Send + Sync>> {
     match version {
         "1.1" => Ok(65537),
         "1.2" => Ok(65538),
@@ -31,7 +31,7 @@ pub fn parse_jni_version(version: &str) -> Result<u32, Box<dyn Error>> {
     }
 }
 
-pub fn jni_version_to_string(version: i32) -> Result<String, Box<dyn Error>> {
+pub fn jni_version_to_string(version: i32) -> Result<String, Box<dyn Error + Send + Sync>> {
     match version {
         65537 => Ok("1.1".to_string()),
         65538 => Ok("1.2".to_string()),
@@ -44,7 +44,7 @@ pub fn jni_version_to_string(version: i32) -> Result<String, Box<dyn Error>> {
     }
 }
 
-pub type ResultType<T> = Result<T, Box<dyn Error>>;
+pub type ResultType<T> = Result<T, Box<dyn Error + Send + Sync>>;
 
 pub fn jni_type_to_java_type(to_convert: &String) -> String {
     return if to_convert == "Z" || to_convert == "boolean" {

--- a/crates/java-rs/src/library/library.rs
+++ b/crates/java-rs/src/library/library.rs
@@ -15,7 +15,7 @@ type JniCreateJavaVm = unsafe extern "system" fn(
 
 static mut LIBRARY: Mutex<Option<libloading::Library>> = Mutex::new(None);
 
-pub fn load_library(library_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn load_library(library_path: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
     trace!("Loading library: {}", library_path);
     unsafe {
         let mut library = LIBRARY.lock().unwrap();

--- a/crates/java-rs/src/library/methods.rs
+++ b/crates/java-rs/src/library/methods.rs
@@ -1,8 +1,8 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, unused)]
 
-use crate::library::library;
 use crate::library::library_error::LibraryError;
-use crate::util::util::ResultType;
+use crate::library::methods;
+use crate::util::helpers::ResultType;
 use crate::{sys, trace};
 use std::error::Error;
 use std::sync::Mutex;

--- a/crates/java-rs/src/library/mod.rs
+++ b/crates/java-rs/src/library/mod.rs
@@ -1,2 +1,2 @@
-pub mod library;
 pub mod library_error;
+pub mod methods;

--- a/crates/java-rs/src/tests/array_tests.rs
+++ b/crates/java-rs/src/tests/array_tests.rs
@@ -74,14 +74,14 @@ fn object_array_set() {
 #[test]
 fn short_array() {
     let env = get_vm().attach_thread().unwrap();
-    let arr = JavaShortArray::new(&env, &vec![1, 2, 3, 4, 5]).unwrap();
+    let arr = JavaShortArray::new(&env, &[1, 2, 3, 4, 5]).unwrap();
 
     assert_eq!(arr.len().unwrap(), 5);
 
     let data = arr.get_data().unwrap();
     assert_eq!(data.len(), 5);
 
-    for i in 0..data.len() {
-        assert_eq!(data[i], i as i16 + 1);
+    for (i, item) in data.iter().enumerate() {
+        assert_eq!(*item, i as i16 + 1);
     }
 }

--- a/crates/java-rs/src/tests/common.rs
+++ b/crates/java-rs/src/tests/common.rs
@@ -2,7 +2,7 @@ use crate::java::java_vm::JavaVM;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref VM: JavaVM = JavaVM::new(&"1.8".to_string(), None, &vec![]).unwrap();
+    static ref VM: JavaVM = JavaVM::new("1.8", None, &[]).unwrap();
 }
 
 pub fn get_vm() -> JavaVM {

--- a/crates/java-rs/src/tests/method_tests.rs
+++ b/crates/java-rs/src/tests/method_tests.rs
@@ -38,7 +38,7 @@ fn long_method() {
         .get_long_method("longValue", "()J")
         .unwrap()
         .bind(JavaObject::from(&int));
-    assert_eq!(long_value.call(&[]).unwrap(), 1234 as i64);
+    assert_eq!(long_value.call(&[]).unwrap(), 1234_i64);
 }
 
 #[test]
@@ -49,7 +49,7 @@ fn double_method() {
         .get_double_method("doubleValue", "()D")
         .unwrap()
         .bind(JavaObject::from(&int));
-    assert_eq!(double_value.call(&[]).unwrap(), 1234 as f64);
+    assert_eq!(double_value.call(&[]).unwrap(), 1234_f64);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn float_method() {
         .get_float_method("floatValue", "()F")
         .unwrap()
         .bind(JavaObject::from(&int));
-    assert_eq!(float_value.call(&[]).unwrap(), 1234 as f32);
+    assert_eq!(float_value.call(&[]).unwrap(), 1234_f32);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn boolean_method() {
         .get_boolean_method("equals", "(Ljava/lang/Object;)Z")
         .unwrap()
         .bind(JavaObject::from(&int));
-    assert_eq!(boolean_value.call(&[int.as_arg()]).unwrap(), true);
+    assert!(boolean_value.call(&[int.as_arg()]).unwrap());
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn short_method() {
         .get_short_method("shortValue", "()S")
         .unwrap()
         .bind(JavaObject::from(&int));
-    assert_eq!(short_value.call(&[]).unwrap(), 1234 as i16);
+    assert_eq!(short_value.call(&[]).unwrap(), 1234_i16);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn static_boolean_method() {
         .unwrap();
 
     let boolean = method.call(&[Box::new(&str)]).unwrap();
-    assert_eq!(boolean, true);
+    assert!(boolean);
 }
 
 #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "java-bridge",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "java-bridge",
-            "version": "2.5.2",
+            "version": "2.6.0",
             "license": "MIT",
             "devDependencies": {
                 "@napi-rs/cli": "^2.16.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-bridge",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "main": "dist/index.prod.min.js",
     "types": "dist/index.d.ts",
     "description": "A bridge between Node.js and Java APIs",

--- a/test/StringTest.test.ts
+++ b/test/StringTest.test.ts
@@ -5,12 +5,12 @@ import {
     ensureJvm,
     config,
     clearClassProxies,
-    JavaError,
 } from '../.';
-import { Assertion, AssertionError, expect, use } from 'chai';
+import { expect, use } from 'chai';
 import { inspect } from 'util';
 import { JString } from './classes';
 import chaiAsPromised from 'chai-as-promised';
+import { checkJavaErrorCause } from './testUtil';
 
 use(chaiAsPromised);
 
@@ -153,35 +153,34 @@ describe('StringTest', () => {
     });
 
     it('get java error', () => {
-        const checkError = (e: unknown, method: string, parameter: string) => {
-            if (e instanceof AssertionError) {
-                throw e;
-            }
-
-            expect(e).property('cause').to.not.be.null;
-            const error = e as JavaError;
-            expect(error.cause.toString()).to.equal(
-                `java.lang.NullPointerException: Cannot invoke "${method}" because "${parameter}" is null`
-            );
-
-            const stack = error.cause.getStackTraceSync();
-            expect(stack).to.not.be.null;
-            expect(stack).to.be.an('array');
-            expect(stack.length).to.be.greaterThan(0);
-        };
-
         try {
             new JavaString(null);
             expect.fail('Expected an error');
         } catch (e: unknown) {
-            checkError(e, 'java.lang.StringBuffer.toString()', 'buffer');
+            checkJavaErrorCause(
+                e,
+                'Cannot invoke "java.lang.StringBuffer.toString()" because "buffer" is null'
+            );
         }
 
         try {
             new JavaString('').splitSync(null);
             expect.fail('Expected an error');
         } catch (e: unknown) {
-            checkError(e, 'String.length()', 'regex');
+            checkJavaErrorCause(
+                e,
+                'Cannot invoke "String.length()" because "regex" is null'
+            );
+        }
+
+        try {
+            JavaString.valueOfSync(null);
+            expect.fail('Expected an error');
+        } catch (e: unknown) {
+            checkJavaErrorCause(
+                e,
+                'Cannot read the array length because "value" is null'
+            );
         }
     });
 });

--- a/test/classes.d.ts
+++ b/test/classes.d.ts
@@ -23,6 +23,8 @@ export declare class JString extends JavaClass {
 
     splitSync(regex: string): string[];
 
+    split(regex: string): Promise<string[]>;
+
     transform(fn: JavaInterfaceProxy<FunctionInterface<string>>): Promise<this>;
 }
 

--- a/test/testUtil.ts
+++ b/test/testUtil.ts
@@ -7,8 +7,10 @@ import {
     getClassLoader,
     importClass,
     UnknownJavaClass,
+    JavaError,
 } from '../.';
 import { RuntimeClass } from './classes';
+import { AssertionError, expect } from 'chai';
 
 const ToolProvider = importClass('javax.tools.ToolProvider');
 const URLClassLoader = importClass('java.net.URLClassLoader');
@@ -153,3 +155,20 @@ export class ClassTool {
         fs.rmSync(this.outDir, { recursive: true, force: true });
     }
 }
+
+export const checkJavaErrorCause = (e: unknown, errorMessage: string) => {
+    if (e instanceof AssertionError) {
+        throw e;
+    }
+
+    expect(e).property('cause').to.not.be.null;
+    const error = e as JavaError;
+    expect(error.cause.toString()).to.equal(
+        `java.lang.NullPointerException: ${errorMessage}`
+    );
+
+    const stack = error.cause.getStackTraceSync();
+    expect(stack).to.not.be.null;
+    expect(stack).to.be.an('array');
+    expect(stack.length).to.be.greaterThan(0);
+};

--- a/ts-src/definitions.ts
+++ b/ts-src/definitions.ts
@@ -312,7 +312,8 @@ export declare class UnknownJavaClass extends JavaClass {
 export declare class JavaError extends Error {
     /**
      * The throwable that caused this error.
-     * This is only available in synchronous calls.
+     * This is only available in synchronous calls or
+     * if the {@link JavaConfig.asyncJavaExceptionObjects} option is true.
      */
     public readonly cause?: JavaThrowable;
 }

--- a/ts-src/definitions.ts
+++ b/ts-src/definitions.ts
@@ -302,3 +302,67 @@ export declare class UnknownJavaClass extends JavaClass {
      */
     static [member: string]: any;
 }
+
+/**
+ * An error thrown from the java process.
+ * This error may contain the java throwable
+ * that caused this error. The cause is only
+ * available in synchronous calls.
+ */
+export declare class JavaError extends Error {
+    /**
+     * The throwable that caused this error.
+     * This is only available in synchronous calls.
+     */
+    public readonly cause?: JavaThrowable;
+}
+
+/**
+ * A definition for the java throwable class.
+ * @see https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html
+ */
+export declare class JavaThrowable extends UnknownJavaClass {
+    public addSuppressedSync(suppressed: JavaThrowable): void;
+
+    public addSuppressed(suppressed: JavaThrowable): Promise<void>;
+
+    public fillInStackTraceSync(): void;
+
+    public fillInStackTrace(): Promise<void>;
+
+    public getCauseSync(): JavaThrowable;
+
+    public getCause(): Promise<JavaThrowable>;
+
+    public getMessageSync(): string;
+
+    public getMessage(): Promise<string>;
+
+    public getLocalizedMessageSync(): string;
+
+    public getLocalizedMessage(): Promise<string>;
+
+    public getStackTraceSync(): UnknownJavaClass[];
+
+    public getStackTrace(): Promise<UnknownJavaClass[]>;
+
+    public getSuppressedSync(): JavaThrowable[];
+
+    public getSuppressed(): Promise<JavaThrowable[]>;
+
+    public initCauseSync(cause: JavaThrowable): JavaThrowable;
+
+    public initCause(cause: JavaThrowable): Promise<JavaThrowable>;
+
+    public printStackTraceSync(): void;
+
+    public printStackTrace(): Promise<void>;
+
+    public printStackTraceSync(out: JavaObject): void;
+
+    public printStackTrace(out: JavaObject): Promise<void>;
+
+    public setStackTraceSync(stackTrace: UnknownJavaClass[]): void;
+
+    public setStackTrace(stackTrace: UnknownJavaClass[]): Promise<void>;
+}

--- a/ts-src/index.ts
+++ b/ts-src/index.ts
@@ -13,6 +13,8 @@ export {
     Constructor,
     UnknownJavaClassType,
     JavaClassConstructorType,
+    JavaError,
+    JavaThrowable,
 } from './definitions';
 import type * as internal from '../native';
 /**
@@ -23,6 +25,7 @@ import type * as internal from '../native';
 export type { internal };
 export * from './java';
 import * as java from './java';
+
 export default java;
 export { getJavaLibPath, InterfaceProxyOptions } from '../native';
 export { getJavaVersion, getJavaVersionSync } from './util';


### PR DESCRIPTION
Added a new property to each error, called `cause` which will contain the throwable from the Java process (if present):
```ts
import type { JavaError } from 'java-bridge';

try {
    // Call a method that throws an error
    someInstance.someMethodSync();
} catch (e: unknown) {
    const throwable = (e as JavaError).cause;
    throwable.printStackTraceSync();
}
```

Added a config option called `asyncJavaExceptionObjects` to control whether the Java throwable should be returned from async contexts. This is required as enabling this option will cause the JavaScript stack trace to be lost. This option is disabled by default.

```ts
import { importClass } from 'java-bridge';

const SomeClass = importClass('path.to.SomeClass', {
    asyncJavaExceptionObjects: true,
});

try {
    await SomeClass.someMethod();
} catch (e: unknown) {
    const throwable = (e as JavaError).cause;
    throwable.printStackTraceSync();
}
```

closes #102 